### PR TITLE
Server client handling

### DIFF
--- a/docs/server.txt
+++ b/docs/server.txt
@@ -3,6 +3,54 @@ https://beej.us/guide/bgnet/html/split-wide/system-calls-or-bust.html#socket
 
 https://man7.org/linux/man-pages/man2/socket.2.html
 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-/*
+-Communication between client and server has to be done via TCP/IP (v4 or v6).
+-socket - create an endpoint for communication              https://man7.org/linux/man-pages/man2/socket.2.html
+-getsockopt, setsockopt - get and set options on sockets        https://man7.org/linux/man-pages/man2/setsockopt.2.html
+-fcntl - manipulate file descriptor                             https://man7.org/linux/man-pages/man2/fcntl.2.html
+-bind - bind a name to a socket                                                         https://man7.org/linux/man-pages/man2/bind.2.html
+-send  - send a message on a socket https://man7.org/linux/man-pages/man2/send.2.html
+-
+-struct sockaddr_in {                                                                           // https://man7.org/linux/man-pages/man3/sockaddr.3type.html
+-       sa_family_t     sin_family;     // AF_INET/
+-       in_port_t       sin_port;       // Port number
+-       struct in_addr  sin_addr;       //IPv4 address  ;}
+-https://man7.org/linux/man-pages/man3/inet_aton.3.html
+-
+-INADDR_ANY (0.0.0.0)              means any address for socket binding;
+-IPv4                                                                                                           https://man7.org/linux/man-pages/man7/ip.7.html
+-
+-struct in_addr {       uint32_t       s_addr;     }; // address in network byte order
+-htons()  converts the unsigned short integer hostshort  from host byte order to network byte order.  https://man7.org/linux/man-pages/man3/htons.3.html
+-
+-listen - listen for connections on a socket https://man7.org/linux/man-pages/man2/listen.2.html
+-poll - wait for some event on a file descriptor https://man7.org/linux/man-pages/man2/poll.2.html
+-                struct pollfd {
+-                          int   fd;         // file descriptor/
+-                          short events;     //requested events
+-                          short revents;    // returned events
+-                  };
+-
+-       accept -  a connection on a socket https://man7.org/linux/man-pages/man2/accept.2.html
+-Mistakes:
+-socket()       "Failed to create server socket"
+-bind() "Failed to bind server socket to address"
+-listen()       "Failed to listen for incoming connections"
+-accept()       "Failed to accept new client connection"
+-fcntl()        "Failed to set socket to non-blocking mode"
+-*/
+
+
+
+
+++++++++++++++++++++++++++++++++++++++++++++++
+
+
+
+
+
+
 #include <sys/types.h>
 #include <sys/socket.h>
 
@@ -139,4 +187,8 @@ https://man7.org/linux/man-pages/man3/sockaddr.3type.html
 | Server    | Client disconnect          | void handleQuit(Client* client, const std::vector<std::string>& args); |
 | Server    | Reply to ping              | void handlePing(Client* client, const std::vector<std::string>& args); |
 +-----------+----------------------------+----------------------------------------------+
+
+//__________________SEND()
+
+https://man7.org/linux/man-pages/man2/send.2.html 
 

--- a/docs/testIrc.txt
+++ b/docs/testIrc.txt
@@ -1,0 +1,23 @@
+
+STEps to test:
+
+1.terminal:
+
+ make re
+ ./ircserv 6667 password123
+
+2.terminal (netcat)
+ nc localhost 6667
+
+ //test what you need
+ PASS testpass (for now :\r\n = CTR+v, CTR +m, Enter) 
+ or
+ echo -e "PASS test\r\n" | nc localhost 6667
+ 
+
+To stop: 
+2.terminal (netcat) 
+	 Ctrl+D  in netcat 2.terminal (EOF, closes connection)
+
+1.terminal
+	CTRL+C

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -7,6 +7,11 @@ branch server-client handling
     Close fd
     Erase from _clients
     Erase from _pollFds
+	
+[] Move accept() logic from run() to acceptNewClient()
+
+[] Move read() logic from run() to handleClientInput()
+[] Update run() to call these	
 
 27.06
 Branch: irc-run-logic

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -1,3 +1,13 @@
+29.06
+branch server-client handling
+
+[x] sendToClient()
+ 
+ [x]removeClient(fd) properly. It only does:
+    Close fd
+    Erase from _clients
+    Erase from _pollFds
+
 27.06
 Branch: irc-run-logic
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:22 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/06/29 14:14:59 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/06/29 15:21:56 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,7 +62,7 @@ private:
     // Connection & Client Management
     void acceptNewClient();
     void removeClient(int fd, size_t pollFdIndex);
-    void handleClientInput(int fd);
+    void handleClientInput(size_t pollFdIndex);
     void sendToClient(int fd, const std::string &message);
 
     // Command Dispatch & Parsing

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:22 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/06/27 17:34:38 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/06/29 14:14:59 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,7 +61,7 @@ private:
 
     // Connection & Client Management
     void acceptNewClient();
-    void removeClient(int fd);
+    void removeClient(int fd, size_t pollFdIndex);
     void handleClientInput(int fd);
     void sendToClient(int fd, const std::string &message);
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:25 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/06/27 18:28:17 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/06/29 14:20:11 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,52 +43,58 @@ Server::~Server() {}
 int Server::run()
 {
 	//==================== SOCKET CREATION AND SETUP ====================//
-
+	// (socket) Create server socket with TCP (SOCK_STREAM) over IPv4 (AF_INET)
 	_serverFd = socket(AF_INET, SOCK_STREAM, 0); // Create TCP socket
-	checkResult(_serverFd, "SERVER: Failed to create server socket with TCP");
+	checkResult(_serverFd, "Failed to create server socket with TCP");
 
+	// (setsockopt) Allow immediate reuse of port (SO_REUSEADDR) to avoid 'Address already in use' on restart
 	int enableReuseAddress = 1;
 	int serverSockOptResult = setsockopt(_serverFd, SOL_SOCKET, SO_REUSEADDR, &enableReuseAddress, sizeof(enableReuseAddress)); // Allow quick restart on same port
-	checkResult(serverSockOptResult, "SERVER: Failed to set server socket option SO_REUSEADDR");
+	checkResult(serverSockOptResult, "Failed to set server socket option SO_REUSEADDR");
 
+	// (fcntl) Set server socket to non-blocking mode (O_NONBLOCK) so poll() doesn't block indefinitely
 	int serverFileControlResult = fcntl(_serverFd, F_SETFL, O_NONBLOCK); // Set socket to non-blocking mode
-	checkResult(serverFileControlResult, "SERVER: Failed to set server socket to non-blocking mode");
+	checkResult(serverFileControlResult, "Failed to set server socket to non-blocking mode");
 
+	// (sockaddr_in) Define server address for IPv4 (AF_INET), bind to all interfaces (INADDR_ANY) and target port
 	struct sockaddr_in serverAddress;
 	serverAddress.sin_family = AF_INET;
 	serverAddress.sin_port = htons(_port);		// Set port
 	serverAddress.sin_addr.s_addr = INADDR_ANY; // Bind to all interfaces
 
+	// (bind) Bind server socket to IP/Port for incoming TCP connections
 	int serverBindResult = bind(_serverFd, (struct sockaddr *)&serverAddress, sizeof(serverAddress)); // Bind socket to address
-	checkResult(serverBindResult, "SERVER: Failed to bind server socket to port " + intToString(_port));
+	checkResult(serverBindResult, "Failed to bind server socket to port " + intToString(_port));
 
+	// (listen) Start listening for incoming TCP connections with max queue (SOMAXCONN)
 	int serverListenResult = listen(_serverFd, SOMAXCONN); // Start listening for connections
-	checkResult(serverListenResult, "SERVER: Failed to listen on server port " + intToString(_port));
+	checkResult(serverListenResult, "Failed to listen on server port " + intToString(_port));
 
 	//==================== POLL SETUP ====================//
 
-	std::cout << "SERVER: Registering server socket with poll() to monitor for new TCP connections..." << std::endl;
+	std::cout << "Registering server socket with poll() to monitor for new TCP connections..." << std::endl;
 	struct pollfd serverPollFd;
 	serverPollFd.fd = _serverFd;
 	serverPollFd.events = POLLIN; // Interested in incoming connections
 	serverPollFd.revents = 0;
 	_pollFds.push_back(serverPollFd);
 
-	//==================== MAIN SERVER LOOP ====================//
+	//==================== MAIN SERVER LOOP to hanndle events====================//
 
 	while (true)
 	{
+		// (poll) Wait for events on all monitored file descriptors
 		int serverPollResult = poll(_pollFds.data(), _pollFds.size(), 0); // Wait for events on all fds
-		checkResult(serverPollResult, "SERVER: Failed to poll() while waiting for events");
+		checkResult(serverPollResult, "Failed to poll() while waiting for events");
 
-		nfds_t fdIndex = 0;
-		while (fdIndex < _pollFds.size())
+		nfds_t pollFdIndex = 0;
+		while (pollFdIndex < _pollFds.size())
 		{
 			//==================== NEW CONNECTION HANDLING ====================//
 
-			if (_pollFds[fdIndex].fd == _serverFd && (_pollFds[fdIndex].revents & POLLIN))
+			if (_pollFds[pollFdIndex].fd == _serverFd && (_pollFds[pollFdIndex].revents & POLLIN))
 			{
-				while (true) // Accept all pending connections
+				while (true) // accept() all pending  TCP connections
 				{
 					struct sockaddr_in clientAddress;
 					socklen_t clientAddressrLen = sizeof(clientAddress);
@@ -98,24 +104,27 @@ int Server::run()
 					{
 						if (errno != EAGAIN && errno != EWOULDBLOCK) // Real error, not just no more connections
 						{
-							logErrAndThrow("SERVER: Failed to accept new TCP connection");
+							logErrAndThrow("Failed to accept new TCP connection");
 						}
 						break; // No more pending connections
 					}
 
+					// (fcntl) Set client socket to non-blocking mode
 					int clientFileControlResult = fcntl(clientFd, F_SETFL, O_NONBLOCK); // Set client to non-blocking
-					checkResult(clientFileControlResult, "SERVER: Failed to set client socket to non-blocking mode");
+					checkResult(clientFileControlResult, "Failed to set client socket to non-blocking mode");
 
+					// (map) Add new client to _clients tracking
 					if (_clients.find(clientFd) != _clients.end()) // Sanity check for logic error
 					{
-						logErrAndThrow("SERVER: Logic error - client fd already exists in _clients map");
+						logErrAndThrow("Logic error - client fd already exists in _clients map");
 					}
 					else
 					{
 						_clients[clientFd] = new Client(clientFd, "", ""); // Create new client object
-						std::cout << "SERVER: New client connected on fd " << clientFd << std::endl;
+						std::cout << "New client connected on fd " << clientFd << std::endl;
 					}
 
+					// (pollfd) Add new client to poll() monitoring
 					struct pollfd clientPollFd;
 					clientPollFd.fd = clientFd;
 					clientPollFd.events = POLLIN; // Monitor client for incoming data
@@ -123,22 +132,21 @@ int Server::run()
 					_pollFds.push_back(clientPollFd);
 				}
 
-				fdIndex++;
+				pollFdIndex++;
 			}
-			//==================== CLIENT DATA HANDLING ====================//
+			//==================== (close) CLIENT DATA HANDLING ====================//
 
-			else if (_pollFds[fdIndex].revents & POLLIN)
+			else if (_pollFds[pollFdIndex].revents & POLLIN)
 			{
-				int fd = _pollFds[fdIndex].fd;
+				//(read) Incoming data from client over TCP connection
+				int fd = _pollFds[pollFdIndex].fd;
 				char buf[512];
 				ssize_t readBytes = read(fd, buf, sizeof(buf)); // Read incoming data
 
 				if (readBytes == 0)
 				{
-					std::cout << "SERVER: Client on fd " << fd << " disconnected." << std::endl;
-					close(fd);									// Close socket
-					_clients.erase(fd);							// Remove client from map
-					_pollFds.erase(_pollFds.begin() + fdIndex); // Remove fd from poll list
+					logInfo("Client on fd " + intToString(fd)  + " disconnected");
+					removeClient(fd, pollFdIndex);
 				}
 				else if (readBytes > 0)
 				{
@@ -151,31 +159,31 @@ int Server::run()
 						handleCommand(_clients[fd], cmdClient);
 					}
 
-					fdIndex++;
+					pollFdIndex++;
 				}
 				else
 				{
-					checkResult(readBytes, "SERVER: Failed to read from client TCP connection");
-					fdIndex++;
+					checkResult(readBytes, "Failed to read from client TCP connection");
+					pollFdIndex++;
 				}
 			}
 			//==================== CLIENT DISCONNECT OR ERROR ====================//
 
-			else if (_pollFds[fdIndex].revents & (POLLHUP | POLLERR))
+			else if (_pollFds[pollFdIndex].revents & (POLLHUP | POLLERR))
 			{
-				int fd = _pollFds[fdIndex].fd;
+				int fd = _pollFds[pollFdIndex].fd;
 				int fdCloseResult = close(fd); // Close socket
-				checkResult(fdCloseResult, "SERVER: Failed to close client TCP connection on fd " + intToString(fd));
-				std::cout << "SERVER: Closed client TCP connection on fd " << fd << std::endl;
+				checkResult(fdCloseResult, "Failed to close client TCP connection on fd " + intToString(fd));
+				std::cout << "Closed client TCP connection on fd " << fd << std::endl;
 
 				_clients.erase(fd);
-				_pollFds.erase(_pollFds.begin() + fdIndex);
+				_pollFds.erase(_pollFds.begin() + pollFdIndex);
 			}
 			//==================== NO EVENTS, SKIP ====================//
 
 			else
 			{
-				fdIndex++;
+				pollFdIndex++;
 			}
 		}
 	}
@@ -237,7 +245,7 @@ void Server::handleCommand(Client *client, const std::string &line)
 	else if (command == "JOIN")
 		handleJoin(client, arguments);
 	else
-		sendToClient(client->getFd(), "SERVER: Unknown command: " + command + "\r\n");
+		sendToClient(client->getFd(), "Unknown command: " + command + "\r\n");
 }
 
 //======================== PRIVATE: Connection & Client Management ==================//
@@ -247,10 +255,11 @@ void Server::acceptNewClient()
 	logInfo("acceptNewClient() called - Not implemented yet.");
 }
 
-void Server::removeClient(int fd)
+void Server::removeClient(int fd, size_t pollFdIndex)
 {
-	(void)fd;
-	logInfo("removeClient() called - Not implemented yet.");
+	close(fd);									// Close socket
+	_clients.erase(fd);							// Remove client from map
+	_pollFds.erase(_pollFds.begin() + pollFdIndex);  // Remove fd from poll list
 }
 
 void Server::handleClientInput(int fd)
@@ -259,11 +268,16 @@ void Server::handleClientInput(int fd)
 	logInfo("handleClientInput() called - Not implemented yet.");
 }
 
+/*
+	   send - send a message on a socket
+	   ssize_t send(int sockfd, const void buf[.size], size_t size, int flags);
+	   https://man7.org/linux/man-pages/man2/send.2.html
+	    data()- return a const char * (pointer to the beginning of the message)
+	   */
 void Server::sendToClient(int fd, const std::string &message)
 {
-	(void)fd;
-	(void)message;
-	logInfo("sendToClient() called - Not implemented yet.");
+	int sendMsgResult = send(fd, message.data(), message.size(), 0);
+	checkResult(sendMsgResult, "Failed to send a message on socket");
 }
 
 //======================== PRIVATE: Mandatory IRC Command Handlers ==================//
@@ -272,29 +286,29 @@ void Server::handlePass(Client *client, const std::vector<std::string> &params)
 {
 	(void)client;
 	(void)params;
-	
-	sendToClient(client->getFd(), "SERVER: PASS received\r\n");
+
+	sendToClient(client->getFd(), "PASS received\r\n");
 }
 
 void Server::handleNick(Client *client, const std::vector<std::string> &params)
 {
 	(void)client;
 	(void)params;
-	sendToClient(client->getFd(), "SERVER: NICK received\r\n");
+	sendToClient(client->getFd(), "NICK received\r\n");
 }
 
 void Server::handleUser(Client *client, const std::vector<std::string> &params)
 {
 	(void)client;
 	(void)params;
-	sendToClient(client->getFd(), "SERVER: USER received\r\n");
+	sendToClient(client->getFd(), "USER received\r\n");
 }
 
 void Server::handleJoin(Client *client, const std::vector<std::string> &params)
 {
 	(void)client;
 	(void)params;
-	sendToClient(client->getFd(), "SERVER: JOIN received\r\n");
+	sendToClient(client->getFd(), "JOIN received\r\n");
 }
 
 void Server::handlePrivateMessage(Client *client, const std::vector<std::string> &params)
@@ -314,13 +328,15 @@ void Server::checkResult(int result, const std::string &errMsg)
 
 void Server::logErrAndThrow(const std::string &msg)
 {
+	// prints: ESRV=  🤖🔥
 	std::cerr << ESRV << msg << RST << std::endl;
 	throw std::runtime_error("SERVER(errno):  " + std::string(strerror(errno)));
 }
 
 void Server::logInfo(const std::string &msg)
 {
-	std::cout << BLU << SRV << "SERVER:  " << msg << RST << std::endl;
+	// prints: SRV=  🤖🔥
+	std::cout << BLU << SRV << " " << msg << RST << std::endl;
 }
 
 //======================== PUBLIC: HELPER FUNCTIONS ===========================//


### PR DESCRIPTION
29.06
branch server-client handling

[x] sendToClient()
 
 [x]removeClient(fd) properly. It only does:
    Close fd
    Erase from _clients
    Erase from _pollFds

[] Move accept() logic from run() to acceptNewClient()
[] Move read() logic from run() to handleClientInput()
[] Update run() to call these	
[]test 