### PR TITLE
update/canonical-form-disable-copy-assigm in channel. addlogs for all…

### DIFF
--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -52,7 +52,23 @@ TODO in Channel:
 
 
 TODO SERVER/ CLIENT/ CHANNEL /ELSE:
-[] DESTRUCTORS FOR ALL CLASSES MUST  cleaning!
+
+16.07:
+	Branch "feature/shutdown-cleanup"
+	add:
+		DESTRUCTORS update in client and chaneel.
+		add full cleaning in server destructor
+			Client* c = new Client(...)	delete c somewhere (usually in shutdown or destructor)
+			int fd = socket(...)	close(fd)
+			fcntl(fd, F_SETFL, ...)	close(fd) when done
+			std::map<int, Client*>	loop and delete all pointers
+			std::map<std::string, Channel*>	same — delete channels
+	Channel:
+	/*
+	disabled copy constructor, operator=
+		Copying and assignment are disabled for this class.
+		IRC objects must be unique and should never be copied.
+
 
 15.07
 Branch: "feature/signal-handling"

--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:16 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/13 19:09:55 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 07:00:49 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,10 +29,9 @@ class Client
 {
 private:
     //======================== PRIVATE: CONSTRUCTORS  (IRC clients are non-copyable)  ==============//
-    Client();
     Client(const Client &o);
     Client &operator=(const Client &o);
-
+    
     //======================== PRIVATE: SOCKET & IDENTIFICATION =========================//
     int _fd;                // Client socket file descriptor (-1 = no socket)
     std::string _host;      // Client's IP address (used in welcome message)
@@ -40,29 +39,30 @@ private:
     std::string _username;  // Username from USER command
     std::string _realname;  // Realname from USER command
     std::string _userModes; // Modes from USER command
-
+    
     // luis: added the attribute here since will be needed it to join channels
     std::string _password; // Password set by PASS command (if any to use in channels when want to join)
-
+    
     //======================== PRIVATE: REGISTRATION TRACKING ===========================//
     bool _hasProvidedPass; // True if PASS command provided
     bool _hasProvidedNick; // True if NICK command provided
     bool _hasProvidedUser; // True if USER command provided
-
+    
     //======================== PRIVATE: CHANNEL MEMBERSHIP ================================//
     std::vector<Channel *> _channels;      // Channels the client has joined
     std::map<Channel *, bool> _channelOps; // Channels where client is operator
-
+    
     //======================== PRIVATE: DATA BUFFERS ====================================//
     std::string _sendData;     // Buffer for outgoing data (accumulates until \r\n)
     std::string _receivedData; // Buffer for incoming data (accumulates until \r\n)
-
+    
     //======================== PRIVATE: INTERNAL UTILITIES =========================//
     void logInfo(const std::string &msg);   //cyan
     void logError(const std::string &msg); // red - error
-
-public:
+    
+    public:
     //======================== PUBLIC: CONSTRUCTORS & DESTRUCTORS ==============//
+    Client();
     Client(int fd, const std::string &host);
     ~Client();
 

--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:32:27 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/15 18:48:15 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 06:21:41 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,15 +67,17 @@ int main(int argc, char **argv)
         Server server(result.first, result.second);
         globalRunningServer = &server; // 🔥 Required for SIGINT handler to work
         server.run();
+        //cleanup normally, if not triggered by signal
+        globalRunningServer->shutdown();
     }
     catch (const std::exception &e)
     {
         std::cerr << "Error: " << e.what() << std::endl;
         return EXIT_FAILURE;
     }
-       // If server exits normally
-    globalRunningServer->shutdown();
+    
     globalRunningServer = NULL;
 
     return EXIT_SUCCESS;
 }
+

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:42:47 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/13 21:08:24 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 07:02:27 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,36 +63,29 @@ Channel::Channel(const std::string &name, Client &createdBy) : _name(name), _use
 	addUser(createdBy.getFd(), &createdBy); // Add the creator to the channel members
 }
 
-// Copy constructor
+//Alena: copy and operator= must be disabled in irc project
+/*
+	Copy constructor
+	Copying and assignment are disabled for this class.
+ IRC objects must be unique and should never be copied.
+*/
 Channel::Channel(const Channel &other)
 {
-	// Copy the attributes from the other channel
-	_name = other._name;
-	_topic = other._topic;
-	_password = other._password;
-	_members = other._members;
-	_operators = other._operators;
-	_modes = other._modes;
-	_key = other._key;
-	_userLimit = other._userLimit;
+	logError(" Copying a Channel is not allowed: IRC channels must be unique and non-copyable by design.");
+	(void)other;
 }
 
-// Assignment operator
+//Alena: copy and operator= must be disabled in irc project
+/*
+	Assigments operator.
+	Copying and assignment are disabled for this class.
+ IRC objects must be unique and should never be copied.
+*/
 Channel &Channel::operator=(const Channel &other)
 {
-	if (this != &other)
-	{
-		// Check for self-assignment
-		_name = other._name;		   // Copy the name of the channel
-		_topic = other._topic;		   // Copy the topic of the channel
-		_password = other._password;   // Copy the password of the channel
-		_members = other._members;	   // Copy the members of the channel
-		_operators = other._operators; // Copy the operators of the channel
-		_modes = other._modes;		   // Copy the modes of the channel
-		_key = other._key;			   // Copy the key of the channel
-		_userLimit = other._userLimit; // Copy the user limit of the channel
-	}
-	return *this; // Return a reference to this object
+	logError(" Assignment of Channel is forbidden: IRC channels represent unique entities and cannot be duplicated.");
+	(void)other;
+	return *this;
 }
 
 // Destructor
@@ -100,8 +93,7 @@ Channel::~Channel()
 {
 	// No dynamic memory allocation, so nothing to clean up
 	// The vectors and maps will be automatically cleaned up by the destructor
-	logInfo("Channel " + _name  +  " destroyed.");
-	
+	logInfo("Channel destructor called for: " + _name);	
 }
 
 //======================== SETTERS ===================================//

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,29 +6,56 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:20 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/13 19:12:11 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 07:02:35 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/Client.hpp"
 
 //======================== PRIVATE: CONSTRUCTORS  (IRC clients are non-copyable)  ===//
-Client::Client()
-{
-}
 
+/*
+	Copy constructor.
+	Copying and assignment are disabled for this class.
+	IRC clients represent unique socket connections and must not be copied.
+*/
 Client::Client(const Client &o)
 {
+    logError("Copying a Client is not allowed: IRC clients represent unique socket connections.");
     (void)o;
 }
 
+/*
+	Assignment operator.
+	Copying and assignment are disabled for this class.
+	IRC clients represent unique socket connections and must not be duplicated.
+*/
 Client &Client::operator=(const Client &o)
 {
+    logError("Assignment of Client is forbidden: IRC clients represent unique socket connections.");
     (void)o;
     return *this;
 }
 
 //======================== PUBLIC: CONSTRUCTORS & DESTRUCTORS ==================//
+
+Client::Client()
+    : _fd(-1),
+	  _host(""),
+	  _nickname(""),
+	  _username(""),
+	  _userModes(""),
+	  _hasProvidedPass(false),
+	  _hasProvidedNick(false),
+	  _hasProvidedUser(false),
+	  _channels(),
+	  _channelOps(),
+	  _sendData(""),
+	  _receivedData("")
+{
+   
+}
+
 
 Client::Client(int fd, const std::string &host)
     : _fd(fd),
@@ -46,7 +73,10 @@ Client::Client(int fd, const std::string &host)
 {
 }
 
-Client::~Client() {}
+Client::~Client() {
+    logInfo("Client destructor called for fd " + intToString(_fd) + ", nick: " + _nickname);
+	// No need to delete anything — all members are self-managed
+}
 
 //======================== PUBLIC: GETTERS =====================================//
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,17 +6,39 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:25 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/15 19:28:52 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 07:07:51 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/Server.hpp"
 
 //======================== PRIVATE: CONSTRUCTORS  (1 server only) ===================//
+
+/*
+	Default constructor is intentionally disabled.
+	A Server must be explicitly constructed with port and password.
+*/
 Server::Server() {}
-Server::Server(const Server &o) { (void)o; }
+
+/*
+	Copy constructor.
+	Copying and assignment are disabled for this class.
+	IRC Server holds global state, sockets, and file descriptors — it must remain unique.
+*/
+Server::Server(const Server &o) 
+{ 
+	logError("Copying a Server is forbidden: it owns global state, sockets, and runtime structures.");
+	(void)o; 
+}
+
+/*
+	Assignment operator.
+	Copying and assignment are disabled for this class.
+	IRC Server holds global state, sockets, and file descriptors — it must not be duplicated.
+*/
 Server &Server::operator=(const Server &o)
 {
+	logError("Assigning a Server is forbidden: it owns sockets, poll state, and all live connections.");
 	(void)o;
 	return *this;
 }


### PR DESCRIPTION
….IRC objects must be unique

	Channel:
	/*
	disabled copy constructor, operator=
		Copying and assignment are disabled for this class.
		IRC objects must be unique and should never be copied.

Added block comments in all classes for copy/operator=  and logError