### PR TITLE
Fix/segfault join

### DIFF
--- a/commands/commandsChannel.cpp
+++ b/commands/commandsChannel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/16 13:14:55 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 13:31:51 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,9 +59,10 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
 	// Check if the user is already a member of the channel
 	if (channel->hasMembers(&client))
 	{
-		logChannelError("User already in channel");
+		logChannelInfo("User already in channel");
 		return;
 	}
+	
 	// Check if the channel is invite-only and if the user is invited
 	if (channel->isInviteOnly() && !channel->isInvited(client.getFd()))
 	{

--- a/commands/commandsChannel.cpp
+++ b/commands/commandsChannel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/16 12:52:04 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 13:14:55 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@
 #include "../include/utils.hpp"
 #include "../include/replies.hpp"
 
-/* 
+/*
  Function to handle a user joining the channel
 - it check if the channel is not created and created it if needed
 - it check if the user is already a member of the channel
@@ -29,20 +29,21 @@
 */
 void handleJoin(Server &server, Client &client, const std::vector<std::string> &params)
 {
-	if(params.empty())
+	if (params.empty())
 	{
 		replyErr461NeedMoreParams(server.getServerName(), "JOIN");
-		return; 
+		return;
 	}
-	
+
 	std::string channelName = params[0]; // Get the channel name from the parameters
-	
+
 	Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
-	if(!channel){
-		server.addChannel(channelName, client); 
-		logChannelInfo( "Channel " + channelName +" created by " + client.getNickname());
+	if (!channel)
+	{
+		server.addChannel(channelName, client);
+		logChannelInfo("Channel " + channelName + " created by " + client.getNickname());
 		channel = server.getChannel(channelName); // get the just-created channel
-		
+
 		//  first user becomes operator
 		channel->addOperator(client.getFd());
 		logChannelInfo("User " + client.getNickname() + " is  operator(creates channel).");
@@ -54,20 +55,20 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
 		logChannelError("JOIN failed: could not get channel " + channelName);
 		return;
 	}
-	
+
 	// Check if the user is already a member of the channel
 	if (channel->hasMembers(&client))
 	{
 		logChannelError("User already in channel");
 		return;
 	}
-	//Check if the channel is invite-only and if the user is invited
+	// Check if the channel is invite-only and if the user is invited
 	if (channel->isInviteOnly() && !channel->isInvited(client.getFd()))
 	{
 		replyErr473InviteOnlyChan(server.getServerName(), channelName);
 		return;
 	}
-	
+
 	// Check if the channel has a key and if the user's password matches the channel key
 	if (channel->hasKey() && client.getPassword() != channel->getKey())
 	{
@@ -81,52 +82,55 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
 		return;
 	}
 	
-	channel->addUser(client.getFd(), &client); //add user to channel after all the checks	
+
+	channel->addUser(client.getFd(), &client); // add user to channel after all the checks
+
 	client.joinChannel(channel); //  add channel to client's list
-														  // Add the user to the channel
+
+	// Add the user to the channel
 	channel->sendToChannelExcept(client.getNickname() + " has joined the channel.", client); // Notify other members
-	logChannelInfo( "User " + client.getNickname() + " joined channel: " + channelName);
+	logChannelInfo("User " + client.getNickname() + " joined channel: " + channelName);
 }
 
 // Function to handle a user leaving the channel
 void handlePart(Server &server, Client &client, const std::vector<std::string> &params)
 {
-	if(params.empty())
+	if (params.empty())
 		replyErr461NeedMoreParams(server.getServerName(), "PART");
-	std::string channelName = params[0]; // Get the channel name from the parameters
+	std::string channelName = params[0];			   // Get the channel name from the parameters
 	Channel *channel = server.getChannel(channelName); // Get the channel by name from the
-	
-	if(!channel)
+
+	if (!channel)
 		replyErr403NoSuchChannel(server.getServerName(), channelName);
 	if (!channel->hasMembers(&client))
 		replyErr441UserNotInChannel(server.getServerName(), client.getNickname(), channelName);
-	channel->removeUser(client.getFd(), &client); // Remove the user from the channel
-	channel->sendToChannelExcept(client.getNickname() + " has left the channel.",  client); // Notify other members
-	logChannelInfo( "User " + client.getNickname() + " left channel: " + channelName );
+	channel->removeUser(client.getFd(), &client);										   // Remove the user from the channel
+	channel->sendToChannelExcept(client.getNickname() + " has left the channel.", client); // Notify other members
+	logChannelInfo("User " + client.getNickname() + " left channel: " + channelName);
 }
-/* 
+/*
   Function to handle the change of the topic in the channel
 - it checks if the user is an operator before allowing them to change the topic
 - after this check if set the new topic and broadcasts a message to other members
 */
 void handleTopic(Server &server, Client &client, const std::vector<std::string> &params)
 {
-	
-	if(params.size() < 2)
+
+	if (params.size() < 2)
 		replyErr461NeedMoreParams(server.getServerName(), "TOPIC");
-	std::string channelName = params[0]; // Get the channel name from the parameters
-	std::string newTopic = params[1]; // Get the new topic from the parameters 
-	Channel	*channel = server.getChannel(channelName); // Get the channel by name from the server
-	if(!channel)
+	std::string channelName = params[0];			   // Get the channel name from the parameters
+	std::string newTopic = params[1];				   // Get the new topic from the parameters
+	Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
+	if (!channel)
 		replyErr403NoSuchChannel(server.getServerName(), channelName);
 	if (!channel->isOperator(&client))
 		replyErr482ChanOpPrivsNeeded(server.getServerName(), channelName);
-	channel->setTopic(newTopic); // Use the setter to change the topic of the channel
+	channel->setTopic(newTopic);										   // Use the setter to change the topic of the channel
 	channel->sendToChannelExcept("Topic changed to: " + newTopic, client); // Notify other members
-	logChannelInfo( "Topic changed to: " + newTopic + " by " + client.getNickname() );
+	logChannelInfo("Topic changed to: " + newTopic + " by " + client.getNickname());
 }
 
-/* 
+/*
  Function to handle the change of modes in the channel
 - it checks if the user is an operator before allowing them to change modes
 - after this check it sets the mode and captures the boolean enable to determine if the mode is being enabled or disabled
@@ -134,23 +138,23 @@ void handleTopic(Server &server, Client &client, const std::vector<std::string> 
 */
 void handleMode(Server &server, Client &client, const std::vector<std::string> &params)
 {
-	if(params.size() < 3)
+	if (params.size() < 3)
 		replyErr461NeedMoreParams(server.getServerName(), "MODE");
-	std::string channelName = params[0]; // Get the channel name from the parameters
-	char mode = params[1][0]; // Get the mode character from the parameters
-	bool enable = (params[2] == "true"); //check if the mode is being enabled or disabled
+	std::string channelName = params[0];			   // Get the channel name from the parameters
+	char mode = params[1][0];						   // Get the mode character from the parameters
+	bool enable = (params[2] == "true");			   // check if the mode is being enabled or disabled
 	Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
-	if(!channel)
+	if (!channel)
 		replyErr403NoSuchChannel(server.getServerName(), channelName); // If the channel does not exist, return with an error message
 	if (!channel->isOperator(&client))
 		replyErr482ChanOpPrivsNeeded(server.getServerName(), channelName);
 	channel->setMode(mode, enable); // Use the setter to change the mode
 	std::string modeStatus = enable ? "enabled" : "disabled";
 	channel->sendToChannelExcept("Mode '" + std::string(1, mode) + "' has been " + modeStatus + ".", client); // Notify other members
-	logChannelInfo( "Mode '" + std::string(1, mode) + "' has been " + modeStatus + " by " + client.getNickname());
+	logChannelInfo("Mode '" + std::string(1, mode) + "' has been " + modeStatus + " by " + client.getNickname());
 }
 
-/* 
+/*
  Function to handle inviting a user to the channel
 - it checks if the user is an operator before allowing them to invite others
 - if the user is already invited, it returns with an error message
@@ -158,50 +162,50 @@ void handleMode(Server &server, Client &client, const std::vector<std::string> &
 */
 void handleInvite(Server &server, Client &client, const std::vector<std::string> &params)
 {
-	if(params.size() < 2)
+	if (params.size() < 2)
 		replyErr461NeedMoreParams(server.getServerName(), "INVITE");
 	std::string channelName = params[0]; // Get the channel name from the parameters
 	std::stringstream ss(params[1]);
 	int targetFd;
 	if (!(ss >> targetFd))
 	{
-		logChannelError( "Error: Invalid file descriptor provided");
+		logChannelError("Error: Invalid file descriptor provided");
 		return; // Handle invalid input
 	}
 	Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
 	if (!channel->isOperator(&client))
 		replyErr482ChanOpPrivsNeeded(server.getServerName(), channelName);
 	if (channel->isInvited(targetFd))
-		replyErr443UserOnChannel(server.getServerName(), client.getNickname(), channelName); // If the user is already invited, return with an error message
-	channel->inviteUser(targetFd);	// Add the user to the invited list
+		replyErr443UserOnChannel(server.getServerName(), client.getNickname(), channelName);			// If the user is already invited, return with an error message
+	channel->inviteUser(targetFd);																		// Add the user to the invited list
 	channel->sendToChannelExcept(client.getNickname() + " has invited a user to the channel.", client); // Notify other members
-	logChannelInfo( "User with fd " + intToString(targetFd) + " invited to channel: " + channelName );
+	logChannelInfo("User with fd " + intToString(targetFd) + " invited to channel: " + channelName);
 }
 
 // Function to handle kicking a user from the channel
 void handleKick(Server &server, Client &client, const std::vector<std::string> &params)
 {
-	if(params.size() < 2)
+	if (params.size() < 2)
 		replyErr461NeedMoreParams(server.getServerName(), "KICK");
 	std::string channelName = params[0]; // Get the channel name from the parameters
 	std::stringstream ss(params[1]);
 	int targetFd;
 	if (!(ss >> targetFd))
 	{
-		logChannelError("Invalid file descriptor provided" );
+		logChannelError("Invalid file descriptor provided");
 		return; // Handle invalid input
 	}
 	std::string reason = (params.size() > 2) ? params[2] : "No reason provided"; // Get the reason for the kick, if provided
-	Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
-	if(!channel)
+	Channel *channel = server.getChannel(channelName);							 // Get the channel by name from the server
+	if (!channel)
 		replyErr403NoSuchChannel(server.getServerName(), channelName); // If the channel does not exist, return with an error message
 	if (!channel->isOperator(&client))
 		replyErr482ChanOpPrivsNeeded(server.getServerName(), channelName);
 	if (!channel->hasMembers(&client))
-		replyErr441UserNotInChannel(server.getServerName(), client.getNickname(), channelName); // If the user is not a member, return with an error message
-	channel->removeUser(targetFd, &client);																							// Remove the user from the channel
+		replyErr441UserNotInChannel(server.getServerName(), client.getNickname(), channelName);							   // If the user is not a member, return with an error message
+	channel->removeUser(targetFd, &client);																				   // Remove the user from the channel
 	channel->sendToChannelExcept(client.getNickname() + " has kicked a user from the channel. Reason: " + reason, client); // Notify other members
-	logChannelInfo( "User with fd " + intToString(targetFd) + " kicked from channel: " + channelName );
+	logChannelInfo("User with fd " + intToString(targetFd) + " kicked from channel: " + channelName);
 }
 
 // Function to handle setting a key for the channel
@@ -209,14 +213,14 @@ void handleKey(Server &server, Client &client, const std::vector<std::string> &p
 {
 	if (params.size() < 2)
 		replyErr461NeedMoreParams(server.getServerName(), "KEY");
-	std::string channelName = params[0]; // Get the channel name from the parameters
-	std::string key = params[1]; // Get the key from the parameters
+	std::string channelName = params[0];			   // Get the channel name from the parameters
+	std::string key = params[1];					   // Get the key from the parameters
 	Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
 	if (!channel)
-		replyErr403NoSuchChannel(server.getServerName(), channelName); 
+		replyErr403NoSuchChannel(server.getServerName(), channelName);
 	if (!channel->isOperator(&client))
 		replyErr482ChanOpPrivsNeeded(server.getServerName(), channelName);
-	channel->setKey(key);														  // Use the setter to change the key
+	channel->setKey(key);												  // Use the setter to change the key
 	channel->sendToChannelExcept("Channel key has been changed", client); // Notify other members
-	logChannelInfo( "Channel key has been set by " + client.getNickname() );
+	logChannelInfo("Channel key has been set by " + client.getNickname());
 }

--- a/docs/testNow.txt
+++ b/docs/testNow.txt
@@ -9,7 +9,7 @@ test memory leaks:
               JOIN #42
               PRIVMSG #42 :Hello world!
               QUIT
-
+Branch: "fix/segfault join"
 
 
 28.06

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -112,6 +112,8 @@ Branch "fix/segfault-join"
 					return;
 				}
 		- client.joinChannel(channel); //  add channel to client's list
+		-fixef rejectin privmsg, because user was added 2 times in channel(Channel(name, creator) + channel->addUser(...);)
+		- fixed adding same client two times with: if (!channel->hasMembers(&client))
 
 
 15.07

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -91,7 +91,27 @@ Branch: refactor/commands-loggs
 	- 
 	- 
 
-
+Branch "fix/segfault-join"
+ handleJoin():
+		- added  after all numeric replies "return;"
+		- added get the just-created channel. Chanell was NUll(segmfault)
+		if(!channel){
+			server.addChannel(channelName, client); 
+			logChannelInfo( "Channel " + channelName +" created by " + client.getNickname());
+			channel = server.getChannel(channelName); // Alena: added get the just-created channel
+		}
+		-added operator=first user:
+		//  first user becomes operator
+		channel->addOperator(client.getFd());
+		logChannelInfo("User " + client.getNickname() + " granted operator status.");
+		-added additional check:
+				//  check in case if smth goes wrong
+				if (!channel)
+				{
+					logChannelError("JOIN failed: could not get channel " + channelName);
+					return;
+				}
+		- client.joinChannel(channel); //  add channel to client's list
 
 
 15.07

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/03 18:20:37 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 12:12:21 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 13:21:10 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,7 @@ void logServerInfo(const std::string &msg)
 /* red + "Server🎟️🤖🔥: " */
 void logServerError(const std::string &msg)
 {
-	std::cerr << " Error: " << ESRV << msg << RST << std::endl;
+	std::cerr  << ESRV << " Error: " << msg << RST << std::endl;
 }
 
 
@@ -67,7 +67,7 @@ void logServerError(const std::string &msg)
    /*  red + "Client🎭👩‍💻🔥: " */
    void logClientError(const std::string &msg)
    {
-       std::cerr << " Error: " << ECLT << msg << RST << std::endl;
+       std::cerr  << ECLT << " Error: " << msg << RST << std::endl;
    }
    
 


### PR DESCRIPTION
Branch "fix/segfault-join"
 handleJoin():
		- added  after all numeric replies "return;"
		- added get the just-created channel. Chanell was NUll(segmfault)
		if(!channel){
			server.addChannel(channelName, client); 
			logChannelInfo( "Channel " + channelName +" created by " + client.getNickname());
			channel = server.getChannel(channelName); // Alena: added get the just-created channel
		}
		-added operator=first user:
		//  first user becomes operator
		channel->addOperator(client.getFd());
		logChannelInfo("User " + client.getNickname() + " granted operator status.");
		-added additional check:
				//  check in case if smth goes wrong
				if (!channel)
				{
					logChannelError("JOIN failed: could not get channel " + channelName);
					return;
				}
		- client.joinChannel(channel); //  add channel to client's list
		-fixef rejectin privmsg, because user was added 2 times in channel(Channel(name, creator) + channel->addUser(...);)
		- fixed adding same client two times with: if (!channel->hasMembers(&client))