### PR TITLE
Fix/channel commands

### DIFF
--- a/alena_tests/run_tests.sh
+++ b/alena_tests/run_tests.sh
@@ -1,0 +1,19 @@
+#chmod +x run_tests.sh
+# ./run_tests.sh
+
+#!/bin/bash
+echo "🧪 Running all ft_irc tests with Valgrind..."
+
+# Check if ircserv exists
+if [ ! -x ../ircserv ]; then
+  echo "❌ Error: ../ircserv not found or not executable"
+  exit 1
+fi
+
+# Loop over all test scripts
+for script in test_*.sh; do
+  echo "▶️  $script"
+  bash $script
+  echo
+done
+

--- a/alena_tests/test_join.sh
+++ b/alena_tests/test_join.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+PORT=6667
+PASSWORD=pass123
+SERVER=./ircserv
+
+$SERVER $PORT $PASSWORD &
+PID=$!
+sleep 1
+
+{
+  echo "PASS $PASSWORD"
+  echo "NICK user1"
+  echo "USER u1 0 * :User One"
+  echo "JOIN #chan42"
+  sleep 1
+} | nc -C 127.0.0.1 $PORT > output_join.txt
+
+cat output_join.txt
+grep -q "JOIN :#chan42" output_join.txt && echo "✅ JOIN test passed" || echo "❌ JOIN test failed"
+kill $PID

--- a/alena_tests/test_pass_nick_user.sh
+++ b/alena_tests/test_pass_nick_user.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+PORT=6667
+PASSWORD=pass123
+SERVER=../ircserv
+
+# Start the server under valgrind in the background
+valgrind --leak-check=full --log-file=valgrind_pass_nick_user.txt $SERVER $PORT $PASSWORD &
+PID=$!
+sleep 1
+
+{
+  echo "PASS $PASSWORD"
+  echo "NICK user1"
+  echo "USER u1 0 * :User One"
+  sleep 1
+} | nc -C 127.0.0.1 $PORT > output_pass_nick_user.txt
+
+cat output_pass_nick_user.txt
+grep -q ":user1!u1@.* 001" output_pass_nick_user.txt && echo "✅ PASS/NICK/USER test passed" || echo "❌ PASS/NICK/USER test failed"
+
+# Wait for valgrind to flush
+sleep 1
+kill $PID
+
+# Show valgrind summary
+echo "🧠 Valgrind summary:"
+grep -A10 "HEAP SUMMARY" valgrind_pass_nick_user.txt

--- a/commands/commandsChannel.cpp
+++ b/commands/commandsChannel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/16 19:28:25 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 22:05:32 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,12 +48,12 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
 	if (!channel)
 	{
 		server.addChannel(channelName, client);
-		logChannelInfo("Channel " + channelName + " created by " + client.getNickname());
+		
 		channel = server.getChannel(channelName); // get the just-created channel
 
 		//  first user becomes operator
 		channel->addOperator(client.getFd());
-		logChannelInfo("User " + client.getNickname() + " is  operator(creates channel).");
+	
 	}
 
 	//  check in case if smth goes wrong
@@ -96,6 +96,10 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
 
 	// Add the user to the channel
 	channel->sendToChannelExcept(client.getNickname() + " has joined the channel.", client); // Notify other members
+	channel->sendToChannelExcept(
+		":" + client.getPrefix() + " JOIN " + channelName,
+		client
+	); //  More accurate IRC JOIN message format
 	logChannelInfo("User " + client.getNickname() + " joined channel: " + channelName);
 }
 

--- a/commands/commandsChannel.cpp
+++ b/commands/commandsChannel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/16 13:31:51 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 19:28:25 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,13 @@
 */
 void handleJoin(Server &server, Client &client, const std::vector<std::string> &params)
 {
+	
+	if (!client.isRegistered())
+	{
+		replyErr451NotRegistered(server.getServerName(), "JOIN");
+		return;
+	}
+	
 	if (params.empty())
 	{
 		replyErr461NeedMoreParams(server.getServerName(), "JOIN");
@@ -62,7 +69,7 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
 		logChannelInfo("User already in channel");
 		return;
 	}
-	
+
 	// Check if the channel is invite-only and if the user is invited
 	if (channel->isInviteOnly() && !channel->isInvited(client.getFd()))
 	{
@@ -82,7 +89,6 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
 		replyErr471ChannelIsFull(server.getServerName(), channelName);
 		return;
 	}
-	
 
 	channel->addUser(client.getFd(), &client); // add user to channel after all the checks
 

--- a/commands/registration.cpp
+++ b/commands/registration.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/04 11:15:08 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 12:03:49 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 21:28:46 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -275,7 +275,8 @@ https://www.rfc-editor.org/rfc/rfc2812.html#section-3.1.5
 */
 void sendWelcome(Server &server, Client &client)
 {
-	logServerInfo("Welcome message sent to client: " + client.getNickname() + " (" + intToString(client.getFd()) + ")");
+	logServerInfo("Welcome message sent to client '" + client.getNickname() + "' (fd=" + intToString(client.getFd()) + ", ip=" + client.getHost() + ")" );
+
 
 	server.sendToClient(client.getFd(),
 						replyRpl001Welcome(server.getServerName(), client.getNickname(), client.getUsername(), client.getHost()));

--- a/docs/testNow.txt
+++ b/docs/testNow.txt
@@ -7,9 +7,9 @@ test memory leaks:
               USER testuser 0 * :Real Name
               
               JOIN #42
-              PRIVMSG #42 :Hello world!
+              PRIVMSG #git che42 :Hello world!
               QUIT
-Branch: "fix/segfault join"
+
 
 
 28.06

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -115,6 +115,50 @@ Branch "fix/segfault-join"
 		-fixef rejectin privmsg, because user was added 2 times in channel(Channel(name, creator) + channel->addUser(...);)
 		- fixed adding same client two times with: if (!channel->hasMembers(&client))
 
+BRANCH:		fix/channel-commands
+
+		1. PROBLEM:
+			
+		  	[] nc -C 127.0.0.1 6667
+			PASS p
+			JOIN a
+
+			
+			BUT server accept not registered client!
+				Server🎟️🤖: New client connected on fd 4 (127.0.0.1)
+				Server🎟️🤖: Received command from client fd 4: PASS p
+				Server🎟️🤖: Received command from client fd 4: JOIN a
+				Channel🎪💬: Client added to channel: 
+				Server🎟️🤖: Created channel a by user 
+				Channel🎪💬: Channel a created by 
+				Channel🎪💬: Client added as operator: 4
+				Channel🎪💬: User  is  operator(creates channel).
+				Channel🎪💬: User already in channel
+		2.PROBLEM : user addd 2 times => problem in Channel:handleJoin()
+				User already in channel
+
+		3.Problem. In server teminal: ctrlC, but Client terminal is wrking!
+
+		[X]4.problem:
+		server closed, but client not:(
+			 nc -C 127.0.0.1 6667
+			NOTICE * : Server is shutting down now			//The fd was closed successfully by your server. 
+			clear
+			nc: write failed (0/2): Broken pipe
+		FIX: not a problem: =>
+			nc: write failed (0/2): Broken pipe
+			=> that confirms the socket is fully closed on the server side
+			nc is a simple line-based client — it doesn’t auto-quit on EOF unless it receives nothing.
+			You cannot force nc to quit remotely (only close the connection).
+
+commandsChannel.cpp
+	add:
+		-check if not registered user=> dont allow join channel
+
+registration.cpp:
+	updated loServerinfo for welcome message
+
+
 
 15.07
 Branch: "feature/signal-handling"

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -53,9 +53,15 @@ TODO in Channel:
 
 TODO SERVER/ CLIENT/ CHANNEL /ELSE:
 
+17.07
+BRUNC: /  fix/channel-commands
+TESTCASES:
+	[]JOIN 1 
+		must: JOIN 1
+				:ircserv 476 testuser 1 :Invalid channel name
+
 16.07:
-	//luis: should we check if the channel name starts with '#'?
-	//Alena: yes! I am already checking in Server with function isChannelName
+
 
 	Branch "feature/shutdown-cleanup"
 	add:

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -158,6 +158,9 @@ commandsChannel.cpp
 registration.cpp:
 	updated loServerinfo for welcome message
 
+Client:
+add: function for get prefix + _nickname + "!" + _username + "@" + _host;
+
 
 
 15.07

--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:16 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 10:03:05 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 22:07:43 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,6 +71,7 @@ private:
     std::string getHost() const;     // Get client IP address(used in welcome message)
     std::string getUserModes() const;
     std::string getPassword() const; // Get password set by PASS command
+    std::string getPrefix() const;  //get :nickname!username@host
 
     const std::string &getReceivedData() const;        // Get accumulated received data
     const std::vector<Channel *> &getChannels() const; // Get list of channels, where this client is a member

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:42:47 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 09:44:01 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 22:03:41 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -165,7 +165,8 @@ void Channel::addUser(int fd, Client *client)
 void Channel::addOperator(int fd)
 {
 	_operators.insert(fd); // Add the client's file descriptor (fd) to the _operators set
-	logChannelInfo("Client added as operator: " + intToString(fd) );
+	logChannelInfo("Client with fd " + intToString(fd) + " was granted operator status");
+
 }
 
 /*

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:20 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 10:04:03 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 22:08:11 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -119,6 +119,12 @@ std::string Client::getUserModes() const
 std::string Client::getPassword() const {
     return _password;
 }
+
+std::string Client::getPrefix() const
+{
+	return ":" + _nickname + "!" + _username + "@" + _host;
+}
+
 
 /*
 Get list of channels, where this client is a member

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:20 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 22:08:11 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 07:35:51 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -271,14 +271,3 @@ void Client::removeOperator(Channel *channel)
     _channelOps[channel] = false;
 }
 
-//======================== NON-MEMBER OPERATORS ================================//
-
-const std::ostream &operator<<(std::ostream &os, const Client &o)
-{
-    os << "Client(fd: " << o.getFd();
-    os << ", nickname: " << o.getNickname();
-    os << ", username: " << o.getUsername();
-    os << ", receivedData: " << o.getReceivedData();
-    os << ");" << std::endl;
-    return os;
-}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:25 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 09:56:47 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/16 20:11:06 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,9 +51,6 @@ Server::Server(int port, const std::string &password) : _runningMainLoop(true),
 														_password(password),
 														_serverFd(-1) {}
 
-
-
-
 Server::~Server()
 {
 	logServerInfo("Server destructor called.");
@@ -61,7 +58,6 @@ Server::~Server()
 	// call shutdown if it wasnont already triggered manually by ctrl+c
 	shutdown();
 }
-
 
 //======================== PUBLIC: MAIN SERVER METHODS ==========================//
 int Server::run()
@@ -155,10 +151,9 @@ void Server::shutdown()
 	if (!_runningMainLoop) // prevent double shutdown
 		return;
 
-
 	logSeparateLine("💥Shutdown requested");
 	logServerInfo(" Cleaning all server resources...");
-	
+
 	_runningMainLoop = false;
 
 	// notifying all clients
@@ -166,19 +161,28 @@ void Server::shutdown()
 	{
 		sendToClient(it->first, "NOTICE * : Server is shutting down now\r\n");
 	}
-	
+
+
+	// giving time for clients to receive message
+	usleep(200000); // 200 ms
 
 	// delete and close all clients
-	for (std::map<int, Client*>::iterator it = _clients.begin(); it != _clients.end(); ++it)
+	while (!_clients.empty())
 	{
-		logServerInfo(" Deleting client on fd " + intToString(it->first));
-		close(it->first);
-		delete it->second;
+		int fd = _clients.begin()->first;
+
+		for (size_t i = 0; i < _pollFds.size(); ++i)
+		{
+			if (_pollFds[i].fd == fd)
+			{
+				removeClient(fd, i); //  handles close(), delete, erase from pollFds
+				break;
+			}
+		}
 	}
-	_clients.clear();
 
 	// delete all channels
-	for (std::map<std::string, Channel*>::iterator it = _channels.begin(); it != _channels.end(); ++it)
+	for (std::map<std::string, Channel *>::iterator it = _channels.begin(); it != _channels.end(); ++it)
 	{
 		logServerInfo("Deleting channel: " + it->first);
 		delete it->second;
@@ -196,7 +200,6 @@ void Server::shutdown()
 		_serverFd = -1;
 	}
 
-	
 	logSeparateLine("Server shutdown complete");
 }
 
@@ -228,7 +231,7 @@ void Server::handleCommand(Client *client, const std::string &line)
 	// Ignore empty lines
 	if (command.empty())
 		return;
-		
+
 	// Convert command to uppercase (IRC commands are case-insensitive)
 	std::transform(command.begin(), command.end(), command.begin(), ::toupper);
 
@@ -500,21 +503,21 @@ void Server::removeClientFromAllChannels(Client *client)
 {
 	if (!client)
 		return;
-		
+
 	// copy to avoid using internal vector while modifying it
-	const std::vector<Channel *> channelsCopy = client->getChannels(); 
+	const std::vector<Channel *> channelsCopy = client->getChannels();
 
 	int fd = client->getFd();
 
 	for (size_t i = 0; i < channelsCopy.size(); ++i)
 	{
 		Channel *ch = channelsCopy[i];
-		
+
 		if (!ch)
 			continue; // extra safety
 
 		logServerInfo("Removing client from channel: " + ch->getName());
-		
+
 		// remove client from channel
 		ch->removeUser(fd, client);
 
@@ -544,5 +547,3 @@ void Server::logErrAndThrow(const std::string &msg)
 	logServerError(msg);
 	throw std::runtime_error("SERVER(errno):  " + std::string(strerror(errno)));
 }
-
-

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:25 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 20:11:06 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 07:50:29 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -455,6 +455,16 @@ Channel *Server::getChannelByName(const std::string &channelName)
 }
 
 //======================== PUBLIC: CHANNEL UTILITIES ============================//
+/* 
+Channels names are strings (beginning with a '&', '#', '+' or '!'
+   character) of length up to fifty (50) characters.  Apart from the
+   requirement that the first character is either '&', '#', '+' or '!',
+   the only restriction on a channel name is that it SHALL NOT contain
+   any spaces (' '), a control G (^G or ASCII 7), a comma (',').  Space
+   is used as parameter separator and command is used as a list item
+   separator by the protocol).  A colon (':') can also be used as a
+   delimiter for the channel mask.  Channel names are case insensitive.
+*/
 bool Server::isChannelName(const std::string &name)
 {
 	return !name.empty() && name[0] == '#';


### PR DESCRIPTION
16.07:


	Branch "feature/shutdown-cleanup"
	add:
		DESTRUCTORS update in client and chaneel.
		add full cleaning in server destructor
			Client* c = new Client(...)	delete c somewhere (usually in shutdown or destructor)
			int fd = socket(...)	close(fd)
			fcntl(fd, F_SETFL, ...)	close(fd) when done
			std::map<int, Client*>	loop and delete all pointers
			std::map<std::string, Channel*>	same — delete channels
	Channel:
	/*
	disabled copy constructor, operator=
		Copying and assignment are disabled for this class.
		IRC objects must be unique and should never be copied.

	[]segm fold by JOIN
SERVER:
	removeClinetFromALLChannels():
		add NULL check
		used copy instead original

Branch: refactor/commands-loggs
	-movved logs from classes to utils.cpp to use it in functions outside classes

	Client: deleted <<operator in Server
	- moved commands.cpp(from /src to /cmd)
	-renamed /commands/commands.cpp to /commands/commandsChannel.cpp
	- deleted empty files for commands
	- added  class Channel; to  commands.hpp
	- organized commands.hpp
	- added loginfo to server for registering client
	- 
	- 

Branch "fix/segfault-join"
 handleJoin():
		- added  after all numeric replies "return;"
		- added get the just-created channel. Chanell was NUll(segmfault)
		if(!channel){
			server.addChannel(channelName, client); 
			logChannelInfo( "Channel " + channelName +" created by " + client.getNickname());
			channel = server.getChannel(channelName); // Alena: added get the just-created channel
		}
		-added operator=first user:
		//  first user becomes operator
		channel->addOperator(client.getFd());
		logChannelInfo("User " + client.getNickname() + " granted operator status.");
		-added additional check:
				//  check in case if smth goes wrong
				if (!channel)
				{
					logChannelError("JOIN failed: could not get channel " + channelName);
					return;
				}
		- client.joinChannel(channel); //  add channel to client's list
		-fixef rejectin privmsg, because user was added 2 times in channel(Channel(name, creator) + channel->addUser(...);)
		- fixed adding same client two times with: if (!channel->hasMembers(&client))

BRANCH:		fix/channel-commands

		1. PROBLEM:
			
		  	[] nc -C 127.0.0.1 6667
			PASS p
			JOIN a

			
			BUT server accept not registered client!
				Server🎟️🤖: New client connected on fd 4 (127.0.0.1)
				Server🎟️🤖: Received command from client fd 4: PASS p
				Server🎟️🤖: Received command from client fd 4: JOIN a
				Channel🎪💬: Client added to channel: 
				Server🎟️🤖: Created channel a by user 
				Channel🎪💬: Channel a created by 
				Channel🎪💬: Client added as operator: 4
				Channel🎪💬: User  is  operator(creates channel).
				Channel🎪💬: User already in channel
		2.PROBLEM : user addd 2 times => problem in Channel:handleJoin()
				User already in channel

		3.Problem. In server teminal: ctrlC, but Client terminal is wrking!

		[X]4.problem:
		server closed, but client not:(
			 nc -C 127.0.0.1 6667
			NOTICE * : Server is shutting down now			//The fd was closed successfully by your server. 
			clear
			nc: write failed (0/2): Broken pipe
		FIX: not a problem: =>
			nc: write failed (0/2): Broken pipe
			=> that confirms the socket is fully closed on the server side
			nc is a simple line-based client — it doesn’t auto-quit on EOF unless it receives nothing.
			You cannot force nc to quit remotely (only close the connection).

commandsChannel.cpp
	add:
		-check if not registered user=> dont allow join channel

registration.cpp:
	updated loServerinfo for welcome message

Client:
add: function for get prefix + _nickname + "!" + _username + "@" + _host;


