### PR TITLE
Fix/handlejoin replies modes

### DIFF
--- a/commands/join.cpp
+++ b/commands/join.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/17 15:36:23 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 15:56:26 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,14 +58,14 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
         logChannelInfo("User already in channel");
         return;
     }
-    else
+
+    if (!channel)
     {
         server.addChannel(channelName, client);
-
-        channel = server.getChannel(channelName); // get the just-created channel
-
-        //  first user becomes operator
+        channel = server.getChannel(channelName);
         channel->addOperator(client.getFd());
+       
+
     }
 
     //  check in case if smth goes wrong
@@ -98,7 +98,7 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
     {
         server.sendToClient(
             client.getFd(),
-            replyErr471ChannelIsFull(server.getServerName(), channelName));
+            replyErr471ChannelIsFull(server.getServerName(), client.getNickname(), channelName));
         return;
     }
 
@@ -124,5 +124,5 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
         client.getFd(),
         replyRpl366EndOfNames(server.getServerName(), client.getNickname(), channelName));
 
-    logChannelInfo("[joinChannel] User " + client.getNickname() + " joined channel: " + channelName);
+    logChannelInfo("[JOIN]  User " + client.getNickname() + " joined channel: " + channelName);
 }

--- a/commands/join.cpp
+++ b/commands/join.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/17 11:48:56 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 15:36:23 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,21 +52,13 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
     }
 
     Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
-    
-     if (channel && channel->hasMembers(&client)) // Already in the channel
-        return;
 
-    if(channel)
+    if (channel && channel->hasMembers(&client))
     {
-        
-        // Check if the user is already a member of the channel
-        if (channel && channel->hasMembers(&client))
-        {
-            logChannelInfo("User already in channel");
-            return;
-        }
+        logChannelInfo("User already in channel");
+        return;
     }
-    else 
+    else
     {
         server.addChannel(channelName, client);
 
@@ -86,31 +78,51 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
     // Check if the channel is invite-only and if the user is invited
     if (channel->isInviteOnly() && !channel->isInvited(client.getFd()))
     {
-        replyErr473InviteOnlyChan(server.getServerName(), channelName);
+        server.sendToClient(
+            client.getFd(),
+            replyErr473InviteOnlyChan(server.getServerName(), client.getNickname(), channelName));
+
         return;
     }
 
     // Check if the channel has a key and if the user's password matches the channel key
     if (channel->hasKey() && client.getPassword() != channel->getKey())
     {
-        replyErr475BadChannelKey(server.getServerName(), channelName);
+        server.sendToClient(
+            client.getFd(),
+            replyErr475BadChannelKey(server.getServerName(), client.getNickname(), channelName));
         return;
     }
     // Check if the channel has a user limit and if it is reached
     if (channel->hasUserLimit() && static_cast<int>(channel->getMembers().size()) >= channel->getLimit())
     {
-        replyErr471ChannelIsFull(server.getServerName(), channelName);
+        server.sendToClient(
+            client.getFd(),
+            replyErr471ChannelIsFull(server.getServerName(), channelName));
         return;
     }
 
     channel->addUser(client.getFd(), &client); // add user to channel after all the checks
 
     client.joinChannel(channel); //  add channel to client's list
-
-    // Add the user to the channel
-    channel->sendToChannelExcept(client.getNickname() + " has joined the channel.", client); // Notify other members
+    // Send JOIN message to others
     channel->sendToChannelExcept(
         ":" + client.getPrefix() + " JOIN " + channelName,
-        client); //  More accurate IRC JOIN message format
-    logChannelInfo("User " + client.getNickname() + " joined channel: " + channelName);
+        client);
+
+    // Echo JOIN to the joining client
+    server.sendToClient(
+        client.getFd(),
+        ":" + client.getPrefix() + " JOIN " + channelName);
+
+    // Send namelist and end of names
+    server.sendToClient(
+        client.getFd(),
+        replyRpl353NamReply(server.getServerName(), client.getNickname(), "=", channelName, channel->getNickList()));
+
+    server.sendToClient(
+        client.getFd(),
+        replyRpl366EndOfNames(server.getServerName(), client.getNickname(), channelName));
+
+    logChannelInfo("[joinChannel] User " + client.getNickname() + " joined channel: " + channelName);
 }

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -16,6 +16,35 @@ TODO SERVER/ CLIENT/ CHANNEL /ELSE:
 17.07
 
 BRUNCH: test/join
+	-deleted 46! git branches
+			% git branch -r | wc -l                                              
+			46
+			% for branch in $(git branch -r | grep -v "origin/main" | sed 's/origin\///'); do
+			git push origin --delete "$branch"
+			done
+
+join.cpp:
+	[x] send() to client, no just  replie with numeric isValidUsername
+		    function:void Server::sendToClient(int fd, const std::string &message)
+	    	
+			server.sendToClient(
+        client.getFd(),
+           replyErr473InviteOnlyChan(server.getServerName(), client.getNickname(), channelName));
+
+			from:	
+        	replyErr473InviteOnlyChan(server.getServerName(), channelName);
+
+	[x] added irc-format notify: :n!user@host JOIN #channel
+	// send irc formt  JOIN message to other channel members
+    channel->sendToChannelExcept(
+        ":" + client.getPrefix() + " JOIN " + channelName,
+        client);
+	[x] changed 473 for irc standart: <server> 473 <nick> <channel> :Cannot join channel (+i)
+
+	[x] added required: replyRplNamReply (353)
+	[x] added required: replyRplEndOfNames (366)
+
+
 
 
 BRUNCH: git branch -m fix-user-realname-channel-pass

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -15,7 +15,7 @@ TODO SERVER/ CLIENT/ CHANNEL /ELSE:
 
 17.07
 
-BRUNCH: test/join
+BRUNCH: fix/handlejoin-replies-modes
 	-deleted 46! git branches
 			% git branch -r | wc -l                                              
 			46

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Channel.hpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lperez-h <lperez-h@student.42.fr>          +#+  +:+       +#+        */
+/*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:42:32 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 16:33:09 by lperez-h         ###   ########.fr       */
+/*   Updated: 2025/07/17 15:38:56 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,14 +51,14 @@ public:
 	Channel(const std::string &name, Client &createdBy); // Constructor with channel name and channel creator
 	~Channel();											 // Destructor
 
-	void addUser(int fd, Client *client);	 // done
-	void addOperator(int fd);				 // done
-	void removeUser(int fd, Client *client); // done
+	void addUser(int fd, Client *client);	 
+	void addOperator(int fd);				 
+	void removeUser(int fd, Client *client); 
 
-	bool hasMembers(Client *client) const; // done
-	bool isOperator(Client *client) const; // done
+	bool hasMembers(Client *client) const; 
+	bool isOperator(Client *client) const; 
 
-	void sendToChannelExcept(const std::string &message, const Client &clientExcluded) const; // done
+	void sendToChannelExcept(const std::string &message, const Client &clientExcluded) const; 
 
 	void inviteUser(int fd);	  // Add user to invited list -> done
 	bool isInvited(int fd) const; // Check if user is invited -> done
@@ -68,20 +68,21 @@ public:
 	bool hasUserLimit() const;	  // Check if channel has a user limit set -> done
 
 	// Setters
-	void setTopic(const std::string &topic); // done
-	void setMode(char mode, bool enable);	 // done
-	void setName(std::string name);			 // done
-	void setKey(const std::string &key);	 // done
-	void setLimit(int _userLimit);			 // done
+	void setTopic(const std::string &topic); 
+	void setMode(char mode, bool enable);	 
+	void setName(std::string name);			 
+	void setKey(const std::string &key);	 
+	void setLimit(int _userLimit);			 
 
 	// Getters
-	std::string getName() const;				// done
-	std::string getTopic() const;				// -> done
-	std::string getPassword() const;			// -> done
-	std::map<int, Client *> getMembers() const; //-> done
-	std::set<int> getOperators() const;			// -> done
-	std::string getKey() const;					// -> done
-	int getLimit() const;						// -> done
+	std::string getName() const;				
+	std::string getNickList() const;
+	std::string getTopic() const;				
+	std::string getPassword() const;			
+	std::map<int, Client *> getMembers() const;
+	std::set<int> getOperators() const;			
+	std::string getKey() const;					
+	int getLimit() const;						
 };
 
 #endif

--- a/include/replies.hpp
+++ b/include/replies.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 10:12:36 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 15:44:43 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 15:49:27 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -200,10 +200,11 @@ std::string replyErr462AlreadyRegistered(const std::string &server);
 std::string replyErr464PasswordMismatch(const std::string &server);
 
 /* 471 ERR_CHANNELISFULL
-   "<channel> :Cannot join channel (+l)"
    - Sent when a channel has reached its user limit.
+   :ircserv 471 <nick> <channel> :Cannot join channel (+l)
 */
-std::string replyErr471ChannelIsFull(const std::string &server, const std::string &channel);
+std::string replyErr471ChannelIsFull(const std::string &server, const std::string &nick, const std::string &channel);
+
 
 /* 473 ERR_INVITEONLYCHAN
    "<channel> :Cannot join channel (+i)"

--- a/include/replies.hpp
+++ b/include/replies.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 10:12:36 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 08:41:38 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 15:44:43 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,13 +95,14 @@ std::string replyRpl332Topic(const std::string &server, const std::string &chann
    "= <channel> :[[@|+]<nick> [[@|+]<nick> [...]]]"
    - Lists users visible on the channel.
 */
-std::string replyRpl353NamReply(const std::string &server, const std::string &channel, const std::string &names);
+std::string replyRpl353NamReply(const std::string &server, const std::string &nick, const std::string &symbol, const std::string &channel, const std::string &names);
+
 
 /* 366 RPL_ENDOFNAMES
-   "<channel> :End of /NAMES list"
-   - Indicates the end of the NAMES list for a channel.
+"<channel> :End of /NAMES list"
+- Indicates the end of the NAMES list for a channel.
 */
-std::string replyRpl366EndOfNames(const std::string &server, const std::string &channel);
+std::string replyRpl366EndOfNames(const std::string &server, const std::string &nick, const std::string &channel);
 
 /* 401 ERR_NOSUCHNICK
    "<nickname> :No such nick/channel"
@@ -176,6 +177,8 @@ std::string replyErr443UserOnChannel(const std::string &server, const std::strin
 */
 std::string replyErr451NotRegistered(const std::string &server, const std::string &command);
 
+
+
 /* 461 ERR_NEEDMOREPARAMS
    "<command> :Not enough parameters"
    - Returned when a command lacks required parameters.
@@ -206,13 +209,16 @@ std::string replyErr471ChannelIsFull(const std::string &server, const std::strin
    "<channel> :Cannot join channel (+i)"
    - Returned when trying to join an invite-only channel without an invitation.
 */
-std::string replyErr473InviteOnlyChan(const std::string &server, const std::string &channel);
+std::string replyErr473InviteOnlyChan(const std::string &server, const std::string &nick, const std::string &channel);
 
 /* 475 ERR_BADCHANNELKEY
    "<channel> :Cannot join channel (+k)"
    - Used when an incorrect channel key (password) is provided.
 */
-std::string replyErr475BadChannelKey(const std::string &server, const std::string &channel);
+std::string replyErr475BadChannelKey(const std::string &server, const std::string &nick, const std::string &channel);
+
+
+
 
 /* 
  476 ERR_BADCHANMASK

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:42:47 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/16 22:03:41 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 15:39:37 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,6 +107,30 @@ void Channel::setLimit(int limit)
 }
 
 //======================== GETTERS ===================================//
+
+std::string Channel::getNickList() const
+{
+    std::string list;
+
+    for (std::map<int, Client*>::const_iterator it = _members.begin(); it != _members.end(); ++it)
+    {
+        int fd = it->first;
+        Client* client = it->second;
+
+        if (_operators.find(fd) != _operators.end())
+            list += "@" + client->getNickname();
+        else
+            list += client->getNickname();
+
+        list += " ";
+    }
+
+    if (!list.empty())
+        list.erase(list.end() - 1); // Remove trailing space
+
+    return list;
+}
+
 
 // get the limit of users in the channel
 int Channel::getLimit() const

--- a/src/replies.cpp
+++ b/src/replies.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 10:13:16 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 15:44:15 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 15:49:43 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -138,10 +138,11 @@ std::string replyErr464PasswordMismatch(const std::string &server)
     return ":" + server + " " + ERR_PASSWDMISMATCH + " :Password incorrect\r\n";
 }
 
-std::string replyErr471ChannelIsFull(const std::string &server, const std::string &channel)
+std::string replyErr471ChannelIsFull(const std::string &server, const std::string &nick, const std::string &channel)
 {
-    return ":" + server + " " + ERR_CHANNELISFULL + " " + channel + " :Cannot join channel (+l)\r\n";
+    return ":" + server + " 471 " + nick + " " + channel + " :Cannot join channel (+l)\r\n";
 }
+
 
 std::string replyErr473InviteOnlyChan(const std::string &server, const std::string &nick, const std::string &channel)
 {

--- a/src/replies.cpp
+++ b/src/replies.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 10:13:16 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 08:41:12 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 15:44:15 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,15 +45,23 @@ std::string replyRpl332Topic(const std::string &server, const std::string &chann
     return ":" + server + " " + RPL_TOPIC + " " + channel + " :" + topic + "\r\n";
 }
 
-std::string replyRpl353NamReply(const std::string &server, const std::string &channel, const std::string &names)
+std::string replyRpl353NamReply(const std::string &server,
+                                 const std::string &nick,
+                                 const std::string &symbol,
+                                 const std::string &channel,
+                                 const std::string &names)
 {
-    return ":" + server + " " + RPL_NAMREPLY + " = " + channel + " :" + names + "\r\n";
+    return ":" + server + " 353 " + nick + " " + symbol + " " + channel + " :" + names + "\r\n";
 }
 
-std::string replyRpl366EndOfNames(const std::string &server, const std::string &channel)
+
+std::string replyRpl366EndOfNames(const std::string &server,
+                                   const std::string &nick,
+                                   const std::string &channel)
 {
-    return ":" + server + " " + RPL_ENDOFNAMES + " " + channel + " :End of /NAMES list\r\n";
+    return ":" + server + " 366 " + nick + " " + channel + " :End of /NAMES list\r\n";
 }
+
 
 std::string replyErr401NoSuchNick(const std::string &server, const std::string &nick)
 {
@@ -135,14 +143,15 @@ std::string replyErr471ChannelIsFull(const std::string &server, const std::strin
     return ":" + server + " " + ERR_CHANNELISFULL + " " + channel + " :Cannot join channel (+l)\r\n";
 }
 
-std::string replyErr473InviteOnlyChan(const std::string &server, const std::string &channel)
+std::string replyErr473InviteOnlyChan(const std::string &server, const std::string &nick, const std::string &channel)
 {
-    return ":" + server + " " + ERR_INVITEONLYCHAN + " " + channel + " :Cannot join channel (+i)\r\n";
+    return ":" + server + " 473 " + nick + " " + channel + " :Cannot join channel (+i)\r\n";
 }
 
-std::string replyErr475BadChannelKey(const std::string &server, const std::string &channel)
+
+std::string replyErr475BadChannelKey(const std::string &server, const std::string &nick, const std::string &channel)
 {
-    return ":" + server + " " + ERR_BADCHANNELKEY + " " + channel + " :Cannot join channel (+k)\r\n";
+    return ":" + server + " " + ERR_BADCHANNELKEY + " " + nick + " " + channel + " :Cannot join channel (+k)\r\n";
 }
 
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/03 18:20:37 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 09:07:32 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 15:43:41 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,41 +18,16 @@ void printWelcomeMessage()
 	std::cout << std::endl;
 
 	std::cout << RED << "🌟✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨🌟" << RST << std::endl;
-	std::cout << ORG << "✨      W E L C O M E      T O   T H E          c I R C u s !                 ✨" << RST << std::endl;
-	std::cout << YEL << "✨               Launch the 🎆 magic by following these steps!                ✨" << RST << std::endl;
+	std::cout << ORG << "✨      W E L C O M E      T O   T H E          c I R C u s !               ✨" << RST << std::endl;
+	std::cout << YEL << "✨                     Launch the  🎆magic below!                           ✨" << RST << std::endl;
 	std::cout << RED << "🌟✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨🌟" << RST << std::endl;
 
 	std::cout << std::endl;
 
-std::cout << BLU << "💫     🎟️   NICK  juggler                      "
-          << PNK << "  // NICK <nickname>" << RST << std::endl;
+	std::cout << CYN << "💫     🎟️   NICK  juggler               " << AQU << "// NICK <nickname>                 " << RST << std::endl;
+	std::cout << BLU << "💫     🤡   USER  clown 0 * :BigTop      " << PNK << "// USER <username> <hostname>...   " << RST << std::endl;
+	std::cout << MAG << "💫     🎪   JOIN  #tent                  " << RED << "// JOIN <#channel>                 " << RST << std::endl;
 
-std::cout << BLU << "💫     🤡   USER  clown 0 * :BigTop            "
-          << PNK << "// USER <username> <hostname> <servername> :<real name>" << RST << std::endl;
-
-std::cout << BLU << "💫     🎪   JOIN  #tent                        "
-          << PNK << "// JOIN <#channel>" << RST << std::endl;
-
-std::cout << BLU << "💫     💬   PRIVMSG  #tent :Hello world!       "
-          << PNK << "// Send message to a channel or user" << RST << std::endl;
-
-std::cout << BLU << "💫     🧑‍⚖️   MODE  #tent +i                   "
-          << PNK << " // MODE <channel> <+/-i|t|k|l> (invite-only|topic lock| key|user limit)" << std::endl;
-
-std::cout << BLU << "💫     🎯   INVITE  friend #tent               "
-          << PNK << "// Invite a user to a channel" << RST << std::endl;
-
-std::cout << BLU << "💫     🥾   KICK  #tent baduser :no clowns!    "
-          << PNK << "// Kick a user from a channel with a reason" << RST << std::endl;
-
-std::cout << BLU << "💫     🎤   TOPIC  #tent :Let’s party!         "
-          << PNK << "// Set or view channel topic" << RST << std::endl;
-
-std::cout << BLU << "💫     👋   PART  #tent                        "
-          << PNK << "// Leave a channel" << RST << std::endl;
-
-std::cout << BLU << "💫     ❌   QUIT  :Goodbye!                    "
-          << PNK << "// Quit IRC server with optional message" << RST << std::endl;
 	std::cout << std::endl;
 	std::cout << std::endl;
 
@@ -62,7 +37,6 @@ std::cout << BLU << "💫     ❌   QUIT  :Goodbye!                    "
 	std::cout << std::endl;
 	std::cout << std::endl;
 }
-
 
 //============================ LOGGER: GLOBAL LOGGING FOR ALL CLASSES ============================//
 
@@ -107,7 +81,7 @@ void logChannelInfo(const std::string &msg)
 void logChannelError(const std::string &msg)
 {
 	//red + "Channel🎪💬🔥: "
-	std::cerr << " Error: " << ECHN << msg << RST << std::endl;
+	std::cerr << ECHN   << " Error: " << msg << RST << std::endl;
 }
 
 


### PR DESCRIPTION
BRUNCH: fix/handlejoin-replies-modes
	-deleted 46! git branches
			% git branch -r | wc -l                                              
			46
			% for branch in $(git branch -r | grep -v "origin/main" | sed 's/origin\///'); do
			git push origin --delete "$branch"
			done

join.cpp:
	[x] send() to client, no just  replie with numeric isValidUsername
		    function:void Server::sendToClient(int fd, const std::string &message)
	    	
			server.sendToClient(
        client.getFd(),
           replyErr473InviteOnlyChan(server.getServerName(), client.getNickname(), channelName));

			from:	
        	replyErr473InviteOnlyChan(server.getServerName(), channelName);

	[x] added irc-format notify: :n!user@host JOIN #channel
	// send irc formt  JOIN message to other channel members
    channel->sendToChannelExcept(
        ":" + client.getPrefix() + " JOIN " + channelName,
        client);
	[x] changed 473 for irc standart: <server> 473 <nick> <channel> :Cannot join channel (+i)

	[x] added required: replyRplNamReply (353)
	[x] added required: replyRplEndOfNames (366)


