### PR TITLE
corrected topic channel

### DIFF
--- a/commands/topic.cpp
+++ b/commands/topic.cpp
@@ -6,36 +6,82 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
+/*   Updated: 2025/07/17 22:39:32 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/commands.hpp"
 
-
 /*
-  Function to handle the change of the topic in the channel
-- it checks if the user is an operator before allowing them to change the topic
-- after this check if set the new topic and broadcasts a message to other members
+  Function to handle the change or query of the topic in a channel
+  - If only channel name is given: sends the current topic or "no topic" message.
+  - If topic is to be changed: checks if the user is allowed (based on +t mode).
+  - Broadcasts the new topic to all members.
 */
 void handleTopic(Server &server, Client &client, const std::vector<std::string> &params)
 {
 
-	if (params.size() < 2){
-		replyErr461NeedMoreParams(server.getServerName(), "TOPIC");
+	if (params.empty())
+	{
+		server.sendToClient(
+			client.getFd(),
+			replyErr461NeedMoreParams(server.getServerName(), "TOPIC"));
 		return;
 	}
-	std::string channelName = params[0];			   // Get the channel name from the parameters
-	std::string newTopic = params[1];				   // Get the new topic from the parameters
+	std::string channelName = params[0]; // Get the channel name from the parameters
+
 	Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
-	if (!channel){
-		replyErr403NoSuchChannel(server.getServerName(), channelName);
+
+	if (!channel)
+	{
+		server.sendToClient(
+			client.getFd(),
+			replyErr403NoSuchChannel(server.getServerName(), channelName));
 		return;
 	}
-	if (!channel->isOperator(&client)){
-		replyErr482ChanOpPrivsNeeded(server.getServerName(), channelName);
+
+	if (!channel->hasMembers(&client))
+	{
+		server.sendToClient(
+			client.getFd(),
+			replyErr442NotOnChannel(server.getServerName(), channelName));
 		return;
 	}
-	channel->setTopic(newTopic);										   // Use the setter to change the topic of the channel
-	channel->sendToChannelExcept("Topic changed to: " + newTopic, client); // Notify other members
+
+	// Topic query (view current topic)
+	if (params.size() == 1)
+	{
+		if (channel->getTopic().empty())
+		{
+			server.sendToClient(
+				client.getFd(),
+				replyRpl331NoTopic(server.getServerName(), channelName, channel->getTopic()));
+		}
+		else
+		{
+			server.sendToClient(
+				client.getFd(),
+				replyRpl332Topic(server.getServerName(), channelName, channel->getTopic()));
+		}
+		return;
+	}
+
+	std::string newTopic = params[1]; // Get the new topic from the parameters
+
+	if (channel->isTopicLocked() && !channel->isOperator(&client))
+	{
+		server.sendToClient(
+			client.getFd(),
+			replyErr482ChanOpPrivsNeeded(server.getServerName(), channelName));
+		return;
+	}
+
+	channel->setTopic(newTopic); // Use the setter to change the topic of the channel
+
+	// Send proper IRC-formatted topic change message to ALL members
+	std::string msg = ":" + client.getPrefix() + " TOPIC " + channelName + " :" + newTopic;
+	channel->sendToChannelAll(msg, server);								   // requires sendToChannelAll(msg, server) to be implemented
+	
+	
 	logChannelInfo("Topic changed to: " + newTopic + " by " + client.getNickname());
 }

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -18,6 +18,32 @@ TODO SERVER/ CLIENT/ CHANNEL /ELSE:
 
 
 17.07
+BRANCH: "fix/handle-topic
+	- add to numeric reply send() from server to client
+
+
+    [x]Topic change is not limited to operators in all cases
+    According to the IRC spec and MODE +t, only when the +t mode is set, operators can change the topic. Otherwise, any member can.
+
+    [x]You're not checking if the client is in the channel
+    Even regular users should be in the channel to view or change topic.
+
+    [x]You're not sending the proper IRC TOPIC message to the channel
+    Format: :<nick> TOPIC <channel> :<new_topic>
+
+    []No support for topic queries
+    TOPIC <channel> (without a second param) is used to view the topic.
+
+ADD:
+	[x] if (!channel->hasMembers(&client))
+	[x]  if (params.size() == 1)
+	[x] replyRpl331NoTopic(
+	[x] 
+	[x] channel->isTopicLocked() &&
+	[x]   notify all, not except 
+		channel->sendToChannelAll(msg, server);								   // requires sendToChannelAll(msg, server) to be implemented
+	 wrong: channel->sendToChannelExcept("Topic changed to: " + newTopic, client); // Notify other members
+
 
 BRANCH: "fix/handle-ick" //kick :) 
 	- add to numeric reply send() from server to client

--- a/include/replies.hpp
+++ b/include/replies.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 10:12:36 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 15:49:27 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/17 22:32:50 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,6 +84,12 @@ std::string replyRpl003Created(const std::string &server, const std::string &dat
    - Provides server information, including version and supported modes.
 */
 std::string replyRpl004MyInfo(const std::string &server);
+
+/* 331 RPL_NOTOPIC
+   "<channel> :No topic is set"
+   - Indicates that no topic has been set for the channel.
+*/
+std::string replyRpl331NoTopic(const std::string &server, const std::string &channel, const std::string &topic);
 
 /* 332 RPL_TOPIC
    "<channel> :<topic>"


### PR DESCRIPTION
BRANCH: "fix/handle-topic
	- add to numeric reply send() from server to client


    [x]Topic change is not limited to operators in all cases
    According to the IRC spec and MODE +t, only when the +t mode is set, operators can change the topic. Otherwise, any member can.

    [x]You're not checking if the client is in the channel
    Even regular users should be in the channel to view or change topic.

    [x]You're not sending the proper IRC TOPIC message to the channel
    Format: :<nick> TOPIC <channel> :<new_topic>

    []No support for topic queries
    TOPIC <channel> (without a second param) is used to view the topic.

ADD:
	[x] if (!channel->hasMembers(&client))
	[x]  if (params.size() == 1)
	[x] replyRpl331NoTopic(
	[x] 
	[x] channel->isTopicLocked() &&
	[x]   notify all, not except 
		channel->sendToChannelAll(msg, server);								   // requires sendToChannelAll(msg, server) to be implemented
	 wrong: channel->sendToChannelExcept("Topic changed to: " + newTopic, client); // Notify other members
