### PR TITLE
Corrected channel mode handling. See description in pull

### DIFF
--- a/commands/mode.cpp
+++ b/commands/mode.cpp
@@ -6,46 +6,89 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/17 19:06:10 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 00:55:53 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/commands.hpp"
-#include "../include/Server.hpp"
-#include "../include/Client.hpp"
-#include "../include/Channel.hpp"
-#include "../include/colors.hpp"
-#include "../include/utils.hpp"
-#include "../include/replies.hpp"
-
-
 
 /*
  Function to handle the change of modes in the channel
-- it checks if the user is an operator before allowing them to change modes
-- after this check it sets the mode and captures the boolean enable to determine if the mode is being enabled or disabled
-- and then broadcasts a message to other members notifying them of the change
+- It checks if the user is an operator before allowing them to change modes
+- Then sets the mode and broadcasts the change
+- MODE #channel +i      → enable invite-only
+- MODE #channel -t      → disable topic lock
+- MODE #channel +k key  → set channel key
+- MODE #channel         → query current modes (no change)
 */
 void handleMode(Server &server, Client &client, const std::vector<std::string> &params)
 {
-	if (params.size() < 3){
-		replyErr461NeedMoreParams(server.getServerName(), "MODE");
-		return;
-	}
-	std::string channelName = params[0];			   // Get the channel name from the parameters
-	char mode = params[1][0];						   // Get the mode character from the parameters
-	bool enable = (params[2] == "true");			   // check if the mode is being enabled or disabled
-	Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
-	if (!channel){
-		replyErr403NoSuchChannel(server.getServerName(), channelName); // If the channel does not exist, return with an error message
-		return;
-	}
-	if (!channel->isOperator(&client)){
-		replyErr482ChanOpPrivsNeeded(server.getServerName(), channelName);
-		return;
-	}
-	channel->setMode(mode, enable); // Use the setter to change the mode
-	std::string modeStatus = enable ? "enabled" : "disabled";
-	channel->sendToChannelExcept("Mode '" + std::string(1, mode) + "' has been " + modeStatus + ".", client); // Notify other members
-	logChannelInfo("Mode '" + std::string(1, mode) + "' has been " + modeStatus + " by " + client.getNickname());
+
+    if (params.empty())
+    {
+        server.sendToClient(
+            client.getFd(),
+            replyErr461NeedMoreParams(server.getServerName(), "MODE"));
+        return;
+    }
+
+    std::string channelName = params[0]; // Get the channel name from the parameters
+
+    // check channel name
+    if (!server.isChannelName(channelName)) // Check for valid prefix, no spaces, length, etc.
+    {
+        server.sendToClient(
+            client.getFd(),
+            replyErr476BadChanMask(server.getServerName(), client.getNickname(), channelName));
+        return;
+    }
+
+    Channel *channel = server.getChannel(channelName); // Get the channel by name from the server
+
+    if (!channel)
+    {
+        server.sendToClient(
+            client.getFd(),
+            replyErr403NoSuchChannel(server.getServerName(), channelName)); // If the channel does not exist, return with an error message
+        return;
+    }
+
+    if (!channel->hasMembers(&client))
+    {
+        server.sendToClient(
+            client.getFd(),
+            replyErr442NotOnChannel(server.getServerName(), channelName));
+        return;
+    }
+
+    // Handle mode query: MODE #chan => means "show modes"
+    if (params.size() == 1)
+    {
+        std::string currentModes = channel->getModes(); // example: "+it"
+        server.sendToClient(
+            client.getFd(),
+            replyRpl324ChannelMode(server.getServerName(), client.getNickname(), channelName, currentModes));
+        return;
+    }
+
+
+    std::string modeString = params[1]; // e.g. "+i", "-t"
+
+    if ((modeString[0] == '+' || modeString[0] == '-') && !channel->isOperator(&client))
+    {
+        server.sendToClient(
+            client.getFd(),
+            replyErr482ChanOpPrivsNeeded(server.getServerName(), channelName));
+        return;
+    }
+
+    char modeChar = modeString[1];
+    bool enable = (modeString[0] == '+');
+
+    channel->setMode(modeChar, enable); // Use the setter to change the mode
+
+    std::string msg = ":" + client.getPrefix() + " MODE " + channelName + " " + modeString;
+    channel->sendToChannelAll(msg, server); // Notify all members
+
+    logChannelInfo("Mode '" + modeString + "' applied on " + channelName + " by " + client.getNickname());
 }

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -19,6 +19,22 @@ TODO SERVER/ CLIENT/ CHANNEL /ELSE:
 
 17.07
 
+BRANCH:
+	Fix
+	params.size() < 3	 Invalid for standard IRC MODE command. The command can be just MODE #chan (to view) or MODE #chan +i (to set). The third parameter (true) is not standard.
+	params[2] == "true"	 Not valid in IRC. You should use +i, -t, +k, etc. inside params[1]
+	sendToChannelExcept(...)	 Kicks, mode changes, etc. should go to all, including the one making the change.
+	"Mode 'x' has been enabled"	 This is not proper IRC format. The correct message is:
+	:<prefix> MODE <channel> <+mode> [value]
+	add getModes()
+	moved from top if (params.size() < 2) => if the client does MODE #channel (to query), which is valid with 1 param, it gets wrongly rejected.
+	replyRpl324ChannelMode(server.getServerName(), client.getNickname(), channelName, currentModes));
+	add  if (params.empty()) instead if (params.size() < 2)
+
+
+
+
+
 BRANCH: "fix/handle-ick" //kick :) 
 	- add to numeric reply send() from server to client
 	- add validation channel name

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:42:32 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 21:26:58 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 00:44:09 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,6 +84,7 @@ public:
 	std::set<int> getOperators() const;
 	std::string getKey() const;
 	int getLimit() const;
+	std::string getModes() const;
 };
 
 #endif

--- a/include/replies.hpp
+++ b/include/replies.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 10:12:36 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 15:49:27 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 00:49:23 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,6 +84,9 @@ std::string replyRpl003Created(const std::string &server, const std::string &dat
    - Provides server information, including version and supported modes.
 */
 std::string replyRpl004MyInfo(const std::string &server);
+
+
+std::string replyRpl324ChannelMode(const std::string &serverName, const std::string &nickname, const std::string &channel, const std::string &modes);
 
 /* 332 RPL_TOPIC
    "<channel> :<topic>"

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:42:47 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 21:25:48 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 00:43:42 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -172,6 +172,25 @@ std::map<int, Client *> Channel::getMembers() const
 std::set<int> Channel::getOperators() const
 {
 	return _operators; // Return the vector of operators in the channel
+}
+
+std::string Channel::getModes() const
+{
+	std::string modes = "+";
+
+	if (_modes.find('i') != _modes.end() && _modes.at('i'))
+		modes += 'i';
+	if (_modes.find('t') != _modes.end() && _modes.at('t'))
+		modes += 't';
+	if (!_key.empty())
+		modes += 'k';
+	if (_userLimit > 0)
+		modes += 'l';
+
+	if (modes == "+")
+		return ""; // No active modes
+
+	return modes;
 }
 
 //======================== MEMBER FUNCTIONS ===========================//

--- a/src/replies.cpp
+++ b/src/replies.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 10:13:16 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 15:49:43 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 00:49:05 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,12 @@ std::string replyRpl004MyInfo(const std::string &server)
 {
     return ":" + server + " " + RPL_MYINFO + " " + server + " 1.0 o oitkl\r\n";
 }
+
+std::string replyRpl324ChannelMode(const std::string &serverName, const std::string &nickname, const std::string &channel, const std::string &modes)
+{
+	return ":" + serverName + " 324 " + nickname + " " + channel + " " + modes + "\r\n";
+}
+
 
 std::string replyRpl331NoTopic(const std::string &server, const std::string &channel, const std::string &topic)
 {


### PR DESCRIPTION

BRANCH:
	Fix
	params.size() < 3	 Invalid for standard IRC MODE command. The command can be just MODE #chan (to view) or MODE #chan +i (to set). The third parameter (true) is not standard.
	params[2] == "true"	 Not valid in IRC. You should use +i, -t, +k, etc. inside params[1]
	sendToChannelExcept(...)	 Kicks, mode changes, etc. should go to all, including the one making the change.
	"Mode 'x' has been enabled"	 This is not proper IRC format. The correct message is:
	:<prefix> MODE <channel> <+mode> [value]
	add getModes()
	moved from top if (params.size() < 2) => if the client does MODE #channel (to query), which is valid with 1 param, it gets wrongly rejected.
	replyRpl324ChannelMode(server.getServerName(), client.getNickname(), channelName, currentModes));
	add  if (params.empty()) instead if (params.size() < 2)


