### PR TITLE
Set and broadcast channel key (+k) with validation, fixed MODE query …

### DIFF
--- a/commands/key.cpp
+++ b/commands/key.cpp
@@ -6,13 +6,30 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/17 20:47:15 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 01:11:59 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/commands.hpp"
 
-// Function to handle setting a key for the channel
+/*
+ Function: handleKey
+
+ Description:
+ Handles the setting of a channel key (MODE +k). This key acts as a password
+ required to join the channel.
+
+ Behavior:
+ - Only operators are allowed to set the key.
+ - Validates channel existence and that the client is in the channel.
+ - If valid, sets the channel key using setKey().
+ - Broadcasts a standard IRC MODE +k message to all users in the channel.
+ - Logs the action for debug or audit purposes.
+
+ Usage:
+    KEY #channel secret
+    → translates to: MODE #channel +k :secret
+*/
 void handleKey(Server &server, Client &client, const std::vector<std::string> &params)
 {
 	if (params.size() < 2)
@@ -55,10 +72,11 @@ void handleKey(Server &server, Client &client, const std::vector<std::string> &p
 
 	channel->setKey(key); // Use the setter to change the key
 
-	// send standard MODE message to other members
-	channel->sendToChannelExcept(
+	// send standard MODE message to ALL other members
+	channel->sendToChannelAll(
 		":" + client.getPrefix() + " MODE " + channelName + " +k :" + key,
-		client);
+		server);
 
-	logChannelInfo("Channel key for " + channelName + " has been set by " + client.getNickname());
+	//KEY #channel secret → MODE #channel +k :secret irc format
+	logChannelInfo("Mode '+k' (key) set for " + channelName + " by " + client.getNickname());
 }

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -16,8 +16,22 @@ So sendToChannel() is useful for all of these.
 TODO SERVER/ CLIENT/ CHANNEL /ELSE:
 
 
+Pull remote main once	git pull origin main
+Set tracking branch	git branch --set-upstream-to=origin/main
 
 17.07
+
+BRANCH: * fix/handle-key-send-all
+	changed the key-setting logic to broadcast the MODE +k message to all channel members (including the operator), making it IRC-compliant.
+	Check if the params vector has at least 2 elements (channel name and key).
+	Validate that the channel name is correctly formatted using isChannelName().
+	Retrieve the channel using server.getChannel().
+	Verify that the channel exists; otherwise, sent 403 ERR_NOSUCHCHANNEL.
+	Checke if the client is an operator in the channel; otherwise, sent 482 ERR_CHANOPRIVSNEEDED.
+	Set the channel key using channel->setKey(key), storing it internally.
+	Sent an IRC-formatted MODE +k :key message to all channel members using sendToChannelAll(...) instead of sendToChannelExcept(...).
+	Logg the change using logChannelInfo(...), clearly showing the key mode was set by the user.``
+
 BRANCH: "fix/handle-topic
 	- add to numeric reply send() from server to client
 


### PR DESCRIPTION
…logic, and made handleMode and handleKey fully IRC-compliant

BRANCH: * fix/handle-key-send-all
	changed the key-setting logic to broadcast the MODE +k message to all channel members (including the operator), making it IRC-compliant.
	Check if the params vector has at least 2 elements (channel name and key).
	Validate that the channel name is correctly formatted using isChannelName().
	Retrieve the channel using server.getChannel().
	Verify that the channel exists; otherwise, sent 403 ERR_NOSUCHCHANNEL.
	Checke if the client is an operator in the channel; otherwise, sent 482 ERR_CHANOPRIVSNEEDED.
	Set the channel key using channel->setKey(key), storing it internally.
	Sent an IRC-formatted MODE +k :key message to all channel members using sendToChannelAll(...) instead of sendToChannelExcept(...).
	Logg the change using logChannelInfo(...), clearly showing the key mode was set by the user.``