### PR TITLE
Fix/channel quit with message add rn

### DIFF
--- a/commands/join.cpp
+++ b/commands/join.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/18 05:55:24 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 08:44:30 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -111,7 +111,7 @@ void handleJoin(Server &server, Client &client, const std::vector<std::string> &
     // Send JOIN message to others
     channel->sendToChannelExcept(
         ":" + client.getPrefix() + " JOIN " + channelName,
-        client);
+        client, server);
 
     // Echo JOIN to the joining client
     server.sendToClient(

--- a/commands/part.cpp
+++ b/commands/part.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 15:56:02 by lperez-h          #+#    #+#             */
-/*   Updated: 2025/07/17 18:30:40 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 08:44:39 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,7 @@ void handlePart(Server &server, Client &client, const std::vector<std::string> &
 
     std::string partMsg = ":" + client.getPrefix() + " PART " + channelName;
 
-    channel->sendToChannelExcept(partMsg, client);
+    channel->sendToChannelExcept(partMsg, client,server);
     server.sendToClient(client.getFd(), partMsg);
 
     channel->removeUser(client.getFd(), &client);

--- a/commands/privmsg.cpp
+++ b/commands/privmsg.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/04 10:36:16 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/14 21:22:30 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 08:47:53 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -152,7 +152,7 @@ void handlePrivateMessage(Server &server, Client &client, const std::vector<std:
         {
                 Channel *channel = server.getChannel(receiver);
                 if (channel)
-                        channel->sendToChannelExcept(messageFormated, client); // or *client if pointer
+                        channel->sendToChannelExcept(messageFormated, client, server); // or *client if pointer
         }
 
         else

--- a/commands/quit.cpp
+++ b/commands/quit.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/04 11:17:52 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/18 08:09:39 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 08:43:45 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,10 +48,11 @@ void handleQuit(Server &server, Client &client, const std::vector<std::string> &
 		if (*it)
 		{
 			
-			(*it)->sendToChannelExcept(quitMsg, client);
+			(*it)->sendToChannelExcept(quitMsg, client, server);
 		}
 	}
 	
+	server.sendToClient(client.getFd(), quitMsg); // send back to quitting client
 	// remove the client from all those channels:
 	server.removeClientFromAllChannels(&client);
 	

--- a/commands/registration.cpp
+++ b/commands/registration.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/04 11:15:08 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/17 11:21:28 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 08:44:58 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -238,7 +238,7 @@ void handleNick(Server &server, Client &client, const std::vector<std::string> &
 		// Send message to all clients in the same channels
 		const std::vector<Channel *> &clientChannels = client.getChannels();
 		for (std::vector<Channel *>::const_iterator it = clientChannels.begin(); it != clientChannels.end(); ++it)
-			(*it)->sendToChannelExcept(messageNickChange, client);
+			(*it)->sendToChannelExcept(messageNickChange, client,server);
 	}
 
 	client.setHasProvidedNick(true);

--- a/docs/testNow.txt
+++ b/docs/testNow.txt
@@ -14,6 +14,7 @@ do:
 - Server running: ./ircserv  6667 password
   test memory leaks: 
         valgrind --leak-check=full ./ircserv 6667 pass
+        valgrind --leak-check=full --show-leak-kinds=all -s ./ircserv 6667 pass
 - All clients use: nc -C 127.0.0.1 6667
 
 ------------------------------------------------------------------------------------
@@ -57,6 +58,12 @@ PRIVMSG #test :hi everyone
 PART #test
 => Expect PART on A
 => Log: B removed
+
++ QUIT :bye for now
++ => Expect: QUIT broadcast to A
++ => Log: B removed from channel
++ => Log: B disconnected
+
 
 ------------------------------------------------------------------------------------
 🖥️ Terminal C — Client "charlie"

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -26,6 +26,16 @@ BRANCH test/channel
 		- changed loInfo from Error for user quit from channel
 		- add remove from _operators
 		- add remove from _invited
+	changed function(A was not receivin quit bye from B)
+	void sendToChannelExcept(const std::string &message, const Client &clientExcluded, Server &server) const;
+
+	[] a invites B, B received invitation with cursor on same line (musr \r\n)
+		=> updated sendToClient() to add "/r/n" for each message
+		=>deleted /r/n/ from all numeric replies (while added to sendToClient centralized") 
+
+	[] 10 ERROR WHILE TESTIN QUIT WITH MESSAGE. BUT only one time (strange)
+		==1116195== ERROR SUMMARY: 10 errors from 10 contexts (suppressed: 0 from 0)
+
 
 BRANCH: fix/handle-quit-inform-all-in-channel
 	[x] bag: user B quit : bye! (quit with message, but in channel nobody receive message bye!)

--- a/docs/toDO.txt
+++ b/docs/toDO.txt
@@ -21,6 +21,12 @@ Set tracking branch	git branch --set-upstream-to=origin/main
 
 18.07
 
+BRANCH test/channel
+	in removeUser():
+		- changed loInfo from Error for user quit from channel
+		- add remove from _operators
+		- add remove from _invited
+
 BRANCH: fix/handle-quit-inform-all-in-channel
 	[x] bag: user B quit : bye! (quit with message, but in channel nobody receive message bye!)
 	[x] bag: sever send logError and not logInfo

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:42:32 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/18 05:56:13 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 08:42:41 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,7 +59,8 @@ public:
 	bool isOperator(Client *client) const;
 
 	void sendToChannelAll(const std::string &message, Server &server);
-	void sendToChannelExcept(const std::string &message, const Client &clientExcluded) const;
+	void sendToChannelExcept(const std::string &message, const Client &clientExcluded, Server &server) const;
+
 
 	void inviteUser(int fd);	  // Add user to invited list -> done
 	bool isInvited(int fd) const; // Check if user is invited -> done

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:42:47 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/18 06:06:41 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 08:27:28 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -219,20 +219,21 @@ This function checks if the user is an operator before removing them
  */
 void Channel::removeUser(int fd, Client *client)
 {
-	if (isOperator(client))
-	{
-		logChannelError("Error: Cannot remove operator from channel.");
-		return;	// return for not execution rest ant prevent delete user
-	}
+	
 	std::map<int, Client *>::iterator it = _members.find(fd);
+	
 	if (it != _members.end() && it->second == client)
 	{
 		_members.erase(it); // Erase the client from the _members map if found
-		logChannelError("Client removed from channel: " + client->getNickname());
+
+		_operators.erase(fd);
+		_invited.erase(fd);
+
+		logChannelInfo("[QUIT] Client left channel: " + client->getNickname());
 	}
 	else
 	{
-		logChannelInfo("Client not found in this channel, are you sure is here?");
+		logChannelInfo("Client not found in this channel:"  + client->getNickname());
 	}
 }
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:42:47 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/18 08:27:28 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 08:43:20 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -272,23 +272,18 @@ void Channel::sendToChannelAll(const std::string &message, Server &server)
 	}
 }
 
-void Channel::sendToChannelExcept(const std::string &message, const Client &clientExcluded) const
+void Channel::sendToChannelExcept(const std::string &message, const Client &clientExcluded, Server &server) const
 {
-	// Iterate through the _members map
 	for (std::map<int, Client *>::const_iterator it = _members.begin(); it != _members.end(); ++it)
 	{
-		int fd = it->first;			 // Get the file descriptor
-		Client *client = it->second; // Get the client pointer
-
-		// Skip the sender (excludeFd)
+		int fd = it->first;
 		if (fd == clientExcluded.getFd())
-		{
 			continue;
-		}
-		// Send the message to the client
-		client->appendToReceivedData(message);
+
+		server.sendToClient(fd, message); // actually sends to socket
 	}
 }
+
 
 // Function to check if the user's file descriptor (fd) is in the _invited set
 bool Channel::isInvited(int fd) const

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 17:31:25 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/18 01:45:06 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 09:00:09 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -443,9 +443,15 @@ void Server::handleClientInput(size_t pollFdIndex)
 	   https://man7.org/linux/man-pages/man2/send.2.html
 		data()- return a const char * (pointer to the beginning of the message)
 	   */
+
 void Server::sendToClient(int fd, const std::string &message)
 {
-	int sendMsgResult = send(fd, message.data(), message.size(), 0);
+	std::string fullMessage = message;
+
+	if (fullMessage.size() < 2 || fullMessage.substr(fullMessage.size() - 2) != "\r\n")
+		fullMessage += "\r\n"; // append \r\n only if missing
+
+	int sendMsgResult = send(fd, fullMessage.data(), fullMessage.size(), 0);
 	checkResult(sendMsgResult, "Failed to send a message on socket");
 }
 

--- a/src/replies.cpp
+++ b/src/replies.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 10:13:16 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/18 09:02:30 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 09:26:27 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,23 +37,23 @@ std::string replyRpl004MyInfo(const std::string &server)
 
 std::string replyRpl324ChannelMode(const std::string &serverName, const std::string &nickname, const std::string &channel, const std::string &modes)
 {
-	return ":" + serverName + " 324 " + nickname + " " + channel + " " + modes ";
+	return ":" + serverName + " 324 " + nickname + " " + channel + " " + modes ;
 }
 
 
 std::string replyRpl331NoTopic(const std::string &server, const std::string &channel, const std::string &topic)
 {
-    return ":" + server + " " + RPL_NOTOPIC + " " + channel + " :" + topic ";
+    return ":" + server + " " + RPL_NOTOPIC + " " + channel + " :" + topic;
 }
 
 std::string replyRpl332Topic(const std::string &server, const std::string &channel, const std::string &topic)
 {
-    return ":" + server + " " + RPL_TOPIC + " " + channel + " :" + topic ";
+    return ":" + server + " " + RPL_TOPIC + " " + channel + " :" + topic ;
 }
 
 std::string replyRpl341Inviting(const std::string &server, const std::string &nick, const std::string &channel)
 {
-    return ":" + server + " 341 " + nick + " " + channel ";
+    return ":" + server + " 341 " + nick + " " + channel;
 }
 
 std::string replyRpl353NamReply(const std::string &server,
@@ -62,7 +62,7 @@ std::string replyRpl353NamReply(const std::string &server,
                                  const std::string &channel,
                                  const std::string &names)
 {
-    return ":" + server + " 353 " + nick + " " + symbol + " " + channel + " :" + names ";
+    return ":" + server + " 353 " + nick + " " + symbol + " " + channel + " :" + names ;
 }
 
 

--- a/src/replies.cpp
+++ b/src/replies.cpp
@@ -6,7 +6,7 @@
 /*   By: akurmyza <akurmyza@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 10:13:16 by akurmyza          #+#    #+#             */
-/*   Updated: 2025/07/18 01:39:11 by akurmyza         ###   ########.fr       */
+/*   Updated: 2025/07/18 09:02:30 by akurmyza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,45 +15,45 @@
 
 std::string replyRpl001Welcome(const std::string &server, const std::string &nick, const std::string &user, const std::string &host)
 {
-    return ":" + server + " " + RPL_WELCOME + " " + nick + " :Welcome to the Internet Relay Network " + nick + "!" + user + "@" + host + "\r\n";
+    return ":" + server + " " + RPL_WELCOME + " " + nick + " :Welcome to the Internet Relay Network " + nick + "!" + user + "@" + host ;
 }
 
 
 
 std::string replyRpl002YourHost(const std::string &server)
 {
-    return ":" + server + " " + RPL_YOURHOST + " :Your host is " + server + ", running version 1.0\r\n";
+    return ":" + server + " " + RPL_YOURHOST + " :Your host is " + server + ", running version 1.0";
 }
 
 std::string replyRpl003Created(const std::string &server, const std::string &date)
 {
-    return ":" + server + " " + RPL_CREATED + " :This server was created " + date + "\r\n";
+    return ":" + server + " " + RPL_CREATED + " :This server was created " + date ;
 }
 
 std::string replyRpl004MyInfo(const std::string &server)
 {
-    return ":" + server + " " + RPL_MYINFO + " " + server + " 1.0 o oitkl\r\n";
+    return ":" + server + " " + RPL_MYINFO + " " + server + " 1.0 o oitkl";
 }
 
 std::string replyRpl324ChannelMode(const std::string &serverName, const std::string &nickname, const std::string &channel, const std::string &modes)
 {
-	return ":" + serverName + " 324 " + nickname + " " + channel + " " + modes + "\r\n";
+	return ":" + serverName + " 324 " + nickname + " " + channel + " " + modes ";
 }
 
 
 std::string replyRpl331NoTopic(const std::string &server, const std::string &channel, const std::string &topic)
 {
-    return ":" + server + " " + RPL_NOTOPIC + " " + channel + " :" + topic + "\r\n";
+    return ":" + server + " " + RPL_NOTOPIC + " " + channel + " :" + topic ";
 }
 
 std::string replyRpl332Topic(const std::string &server, const std::string &channel, const std::string &topic)
 {
-    return ":" + server + " " + RPL_TOPIC + " " + channel + " :" + topic + "\r\n";
+    return ":" + server + " " + RPL_TOPIC + " " + channel + " :" + topic ";
 }
 
 std::string replyRpl341Inviting(const std::string &server, const std::string &nick, const std::string &channel)
 {
-    return ":" + server + " 341 " + nick + " " + channel + "\r\n";
+    return ":" + server + " 341 " + nick + " " + channel ";
 }
 
 std::string replyRpl353NamReply(const std::string &server,
@@ -62,7 +62,7 @@ std::string replyRpl353NamReply(const std::string &server,
                                  const std::string &channel,
                                  const std::string &names)
 {
-    return ":" + server + " 353 " + nick + " " + symbol + " " + channel + " :" + names + "\r\n";
+    return ":" + server + " 353 " + nick + " " + symbol + " " + channel + " :" + names ";
 }
 
 
@@ -70,112 +70,112 @@ std::string replyRpl366EndOfNames(const std::string &server,
                                    const std::string &nick,
                                    const std::string &channel)
 {
-    return ":" + server + " 366 " + nick + " " + channel + " :End of /NAMES list\r\n";
+    return ":" + server + " 366 " + nick + " " + channel + " :End of /NAMES list";
 }
 
 
 std::string replyErr401NoSuchNick(const std::string &server, const std::string &nick)
 {
-    return ":" + server + " " + ERR_NOSUCHNICK + " " + nick + " :No such nick/channel\r\n";
+    return ":" + server + " " + ERR_NOSUCHNICK + " " + nick + " :No such nick/channel";
 }
 
 std::string replyErr403NoSuchChannel(const std::string &server, const std::string &channel)
 {
-    return ":" + server + " " + ERR_NOSUCHCHANNEL + " " + channel + " :No such channel\r\n";
+    return ":" + server + " " + ERR_NOSUCHCHANNEL + " " + channel + " :No such channel";
 }
 
 std::string replyErr404CannotSendToChan(const std::string &server, const std::string &channel)
 {
-    return ":" + server + " " + ERR_CANNOTSENDTOCHAN + " " + channel + " :Cannot send to channel\r\n";
+    return ":" + server + " " + ERR_CANNOTSENDTOCHAN + " " + channel + " :Cannot send to channel";
 }
 
 std::string replyErr411NoRecipient(const std::string &serverName, const std::string &command)
 {
-    return ":" + serverName + " " ERR_NORECIPIENT " * :No recipient given (" + command + ")\r\n";
+    return ":" + serverName + " " ERR_NORECIPIENT " * :No recipient given (" + command + ")";
 }
 
 std::string replyErr412NoTextToSend(const std::string &serverName)
 {
-    return ":" + serverName + " " ERR_NOTEXTTOSEND " * :No text to send\r\n";
+    return ":" + serverName + " " ERR_NOTEXTTOSEND " * :No text to send";
 }
 
 std::string replyErr431NoNickGiven(const std::string &server)
 {
-    return ":" + server + " " + ERR_NONICKNAMEGIVEN + " :No nickname given\r\n";
+    return ":" + server + " " + ERR_NONICKNAMEGIVEN + " :No nickname given";
 }
 
 std::string replyErr432ErroneousNick(const std::string &server, const std::string &nick)
 {
-    return ":" + server + " " + ERR_ERRONEUSNICKNAME + " " + nick + " :Erroneous nickname\r\n";
+    return ":" + server + " " + ERR_ERRONEUSNICKNAME + " " + nick + " :Erroneous nickname";
 }
 
 std::string replyErr433NickInUse(const std::string &server, const std::string &nick)
 {
-    return ":" + server + " " + ERR_NICKNAMEINUSE + " " + nick + " :Nickname is already in use\r\n";
+    return ":" + server + " " + ERR_NICKNAMEINUSE + " " + nick + " :Nickname is already in use";
 }
 
 std::string replyErr441UserNotInChannel(const std::string &server, const std::string &nick, const std::string &channel)
 {
-    return ":" + server + " " + ERR_USERNOTINCHANNEL + " " + nick + " " + channel + " :They aren't on that channel\r\n";
+    return ":" + server + " " + ERR_USERNOTINCHANNEL + " " + nick + " " + channel + " :They aren't on that channel";
 }
 
 std::string replyErr442NotOnChannel(const std::string &server, const std::string &channel)
 {
-    return ":" + server + " " + ERR_NOTONCHANNEL + " " + channel + " :You're not on that channel\r\n";
+    return ":" + server + " " + ERR_NOTONCHANNEL + " " + channel + " :You're not on that channel";
 }
 
 std::string replyErr443UserOnChannel(const std::string &server, const std::string &user, const std::string &channel)
 {
-    return ":" + server + " " + ERR_USERONCHANNEL + " " + user + " " + channel + " :is already on channel\r\n";
+    return ":" + server + " " + ERR_USERONCHANNEL + " " + user + " " + channel + " :is already on channel";
 }
 
 std::string replyErr451NotRegistered(const std::string &server, const std::string &command)
 {
-    return ":" + server + " 451 " + command + " :You have not registered\r\n";
+    return ":" + server + " 451 " + command + " :You have not registered";
 }
 
 std::string replyErr461NeedMoreParams(const std::string &server, const std::string &command)
 {
-    return ":" + server + " " + ERR_NEEDMOREPARAMS + " " + command + " :Not enough parameters\r\n";
+    return ":" + server + " " + ERR_NEEDMOREPARAMS + " " + command + " :Not enough parameters";
 }
 
 std::string replyErr462AlreadyRegistered(const std::string &server)
 {
-    return ":" + server + " " + ERR_ALREADYREGISTRED + " :Unauthorized command (already registered)\r\n";
+    return ":" + server + " " + ERR_ALREADYREGISTRED + " :Unauthorized command (already registered)";
 }
 
 std::string replyErr464PasswordMismatch(const std::string &server)
 {
-    return ":" + server + " " + ERR_PASSWDMISMATCH + " :Password incorrect\r\n";
+    return ":" + server + " " + ERR_PASSWDMISMATCH + " :Password incorrect";
 }
 
 std::string replyErr471ChannelIsFull(const std::string &server, const std::string &nick, const std::string &channel)
 {
-    return ":" + server + " 471 " + nick + " " + channel + " :Cannot join channel (+l)\r\n";
+    return ":" + server + " 471 " + nick + " " + channel + " :Cannot join channel (+l)";
 }
 
 
 std::string replyErr473InviteOnlyChan(const std::string &server, const std::string &nick, const std::string &channel)
 {
-    return ":" + server + " 473 " + nick + " " + channel + " :Cannot join channel (+i)\r\n";
+    return ":" + server + " 473 " + nick + " " + channel + " :Cannot join channel (+i)";
 }
 
 
 std::string replyErr475BadChannelKey(const std::string &server, const std::string &nick, const std::string &channel)
 {
-    return ":" + server + " " + ERR_BADCHANNELKEY + " " + nick + " " + channel + " :Cannot join channel (+k)\r\n";
+    return ":" + server + " " + ERR_BADCHANNELKEY + " " + nick + " " + channel + " :Cannot join channel (+k)";
 }
 
 
 
 std::string replyErr476BadChanMask(const std::string &serverName, const std::string &nickname, const std::string &channel)
 {
-	return ":" + serverName + " 476 " + nickname + " " + channel + " :Bad Channel Mask\r\n";
+	return ":" + serverName + " 476 " + nickname + " " + channel + " :Bad Channel Mask";
 }
 
 
 std::string replyErr482ChanOpPrivsNeeded(const std::string &server, const std::string &channel)
 {
-    return ":" + server + " " + ERR_CHANOPRIVSNEEDED + " " + channel + " :You're not channel operator\r\n";
+    return ":" + server + " " + ERR_CHANOPRIVSNEEDED + " " + channel + " :You're not channel operator";
 }
 


### PR DESCRIPTION
18.07

BRANCH test/channel
	in removeUser():
		- changed loInfo from Error for user quit from channel
		- add remove from _operators
		- add remove from _invited
	changed function(A was not receivin quit bye from B)
	void sendToChannelExcept(const std::string &message, const Client &clientExcluded, Server &server) const;

	[] a invites B, B received invitation with cursor on same line (musr \r\n)
		=> updated sendToClient() to add "/r/n" for each message
		=>deleted /r/n/ from all numeric replies (while added to sendToClient centralized") 

	[] 10 ERROR WHILE TESTIN QUIT WITH MESSAGE. BUT only one time (strange)
		==1116195== ERROR SUMMARY: 10 errors from 10 contexts (suppressed: 0 from 0)
